### PR TITLE
feat: assessment-page photos, in-place save, bulk send-all (#24, #50, #51)

### DIFF
--- a/client/src/pages/AssessmentSummaryPage.jsx
+++ b/client/src/pages/AssessmentSummaryPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { getMasteryForAssignment, syncMasteryForAssignment, writeMasteryScores, writeMasteryComment, createFlag, deleteFlag } from '../services/api.js';
 import { draftKey, readDraft, writeDraft, clearDraft, draftBaseline } from '../lib/assessmentDraft.js';
@@ -45,7 +45,7 @@ function normalizePastedText(text) {
 
 // ── Per-student rubric card ──────────────────────────────────────────────────
 
-export function StudentRubricCard({ student, topics, courseId, assignmentId, assignmentRow, onSaved }) {
+export function StudentRubricCard({ student, topics, courseId, assignmentId, assignmentRow, onSaved, onPendingChange, registerSaver, unregisterSaver }) {
   const loadedDisplay = student.comment_status === 1;
   const storageKey = draftKey(courseId, assignmentId, student.enrollment_id);
   // Signature of the synced Schoology values this card was rendered against.
@@ -134,6 +134,24 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
     }
   }, [hasPendingChanges, pending, comment, display, storageKey, currentBaseline]);
 
+  // ── Page-level "Send all" wiring (#51) ──────────────────────────────────
+  // Report this card's pending state up so the page bar can count unsaved
+  // cards and enable/disable. Register an imperative saver the bar invokes.
+  // saveRef always points at the latest handleSave closure so the registered
+  // thunk saves current state, not a stale snapshot.
+  const saveRef = useRef(null);
+  saveRef.current = handleSave;
+
+  useEffect(() => {
+    onPendingChange?.(student.schoology_uid, hasPendingChanges);
+  }, [hasPendingChanges, student.schoology_uid, onPendingChange]);
+
+  useEffect(() => {
+    const uid = student.schoology_uid;
+    registerSaver?.(uid, () => saveRef.current());
+    return () => unregisterSaver?.(uid);
+  }, [student.schoology_uid, registerSaver, unregisterSaver]);
+
   // Apply a new comment value, auto-flipping the display toggle ON the first
   // time a virgin record's comment goes empty → non-empty. Shared by the
   // textarea's onChange and onPaste handlers.
@@ -206,14 +224,29 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
           commentStatus: display,
         });
       }
+      // Build the post-save score map (pending merged over current) so the page
+      // can patch this one student in place — no full reload, no card unmount
+      // flash (#50). Mirrors the gradeInfo loop but keeps the DB's letter codes.
+      const newScores = {};
+      for (const t of topics) {
+        const level = pending[t.id] ?? student.scores[t.id]?.grade;
+        if (level == null) continue;
+        newScores[t.id] = { points: LEVEL_POINTS[level], grade: level };
+      }
       setSaveResult('saved');
       setPending({});
-      // Explicit clear: onSaved() triggers a page reload that unmounts this
-      // card, so the write effect above will not run to clear the key itself.
+      // Explicit clear: the card stays mounted now, but the write effect runs
+      // asynchronously — clear here so a fast bulk run can't race a stale key.
       clearDraft(storageKey);
-      onSaved?.();
+      onSaved?.(student.schoology_uid, {
+        scores: newScores,
+        grade_comment: comment,
+        comment_status: display ? 1 : null,
+      });
+      return true;
     } catch (err) {
       setSaveResult(`error: ${err.message}`);
+      return false;
     } finally {
       setSaving(false);
     }
@@ -303,6 +336,25 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
         display: 'flex', alignItems: 'center', gap: '0.75rem',
         borderBottom: '1px solid var(--border)',
       }}>
+        {/* Student photo (#24) — mirrors the course-roster avatar pattern, with
+            an initials fallback when no picture has synced. */}
+        {student.picture_url ? (
+          <img
+            src={student.picture_url}
+            alt=""
+            style={{ width: 32, height: 32, borderRadius: '50%', objectFit: 'cover', display: 'block', flexShrink: 0 }}
+            onError={e => { e.currentTarget.style.display = 'none'; }}
+          />
+        ) : (
+          <div style={{
+            width: 32, height: 32, borderRadius: '50%', flexShrink: 0,
+            background: 'var(--bg-subtle)', display: 'flex',
+            alignItems: 'center', justifyContent: 'center',
+            fontSize: '0.75rem', color: 'var(--text-muted)', fontWeight: 600,
+          }}>
+            {(student.first_name?.[0] || '')}{(student.last_name?.[0] || '')}
+          </div>
+        )}
         <Link to={`/student/${student.id}`} className="link" style={{ fontWeight: 600, fontSize: '0.95rem' }}>
           {displayName(student)}
         </Link>
@@ -639,6 +691,63 @@ export default function AssessmentSummaryPage() {
   const [refreshing, setRefreshing] = useState(false);
   const [refreshResult, setRefreshResult] = useState(null);
 
+  // "Send all" bar state (#51). pendingByUid maps each card's uid → true while
+  // it has unsaved changes; saversRef holds each card's imperative save thunk.
+  const [pendingByUid, setPendingByUid] = useState({});
+  const [bulkSaving, setBulkSaving] = useState(false);
+  const [bulkResult, setBulkResult] = useState(null);
+  const saversRef = useRef({});
+
+  // Patch a single student in place after its card saves, instead of reloading
+  // the whole page (#50). Avoids the "Loading..." flash that unmounted every
+  // card on every save during a grading run.
+  const handleCardSaved = useCallback((uid, patch) => {
+    setData(prev => (prev ? {
+      ...prev,
+      students: prev.students.map(s => (s.schoology_uid === uid ? { ...s, ...patch } : s)),
+    } : prev));
+  }, []);
+
+  // Stable registry callbacks (empty deps) so the cards' effects don't churn.
+  // The no-op guard keeps a card reporting an unchanged pending state from
+  // triggering a re-render loop.
+  const handlePendingChange = useCallback((uid, has) => {
+    setPendingByUid(prev => {
+      if (!!prev[uid] === has) return prev;
+      const next = { ...prev };
+      if (has) next[uid] = true; else delete next[uid];
+      return next;
+    });
+  }, []);
+  const registerSaver = useCallback((uid, fn) => { saversRef.current[uid] = fn; }, []);
+  const unregisterSaver = useCallback((uid) => {
+    delete saversRef.current[uid];
+    setPendingByUid(prev => {
+      if (!prev[uid]) return prev;
+      const next = { ...prev }; delete next[uid]; return next;
+    });
+  }, []);
+
+  const totalPending = Object.keys(pendingByUid).length;
+
+  async function handleSendAll() {
+    const uids = Object.keys(pendingByUid);
+    if (uids.length === 0) return;
+    setBulkSaving(true);
+    setBulkResult(null);
+    let ok = 0, fail = 0;
+    for (const uid of uids) {
+      const save = saversRef.current[uid];
+      if (!save) continue;
+      // Sequential: each card writes to Schoology; avoid hammering the API and
+      // keep per-card Saved/error badges legible as they land.
+      const success = await save();
+      if (success) ok++; else fail++;
+    }
+    setBulkResult(`Sent ${ok} grade${ok !== 1 ? 's' : ''}${fail ? `, ${fail} failed` : ''}`);
+    setBulkSaving(false);
+  }
+
   function load() {
     setLoading(true);
     getMasteryForAssignment(courseId, assignmentId)
@@ -715,17 +824,52 @@ export default function AssessmentSummaryPage() {
           <p className="text-muted">No students found. Run a mastery sync for this course first.</p>
         </div>
       ) : (
-        students.map(student => (
-          <StudentRubricCard
-            key={student.schoology_uid}
-            student={student}
-            topics={alignedTopics}
-            courseId={courseId}
-            assignmentId={assignmentId}
-            assignmentRow={assignment}
-            onSaved={load}
-          />
-        ))
+        <>
+          {students.map(student => (
+            <StudentRubricCard
+              key={student.schoology_uid}
+              student={student}
+              topics={alignedTopics}
+              courseId={courseId}
+              assignmentId={assignmentId}
+              assignmentRow={assignment}
+              onSaved={handleCardSaved}
+              onPendingChange={handlePendingChange}
+              registerSaver={registerSaver}
+              unregisterSaver={unregisterSaver}
+            />
+          ))}
+
+          {/* Bulk send-all bar (#51) — sticky so it stays reachable during a
+              fast grading run. */}
+          <div style={{
+            position: 'sticky', bottom: 0, marginTop: '0.5rem',
+            padding: '0.75rem 1rem', background: 'var(--card-bg)',
+            borderTop: '1px solid var(--border)', borderRadius: 10,
+            boxShadow: '0 -2px 8px rgba(0,0,0,0.06)',
+            display: 'flex', alignItems: 'center', gap: '0.75rem',
+          }}>
+            <button
+              className="primary"
+              onClick={handleSendAll}
+              disabled={bulkSaving || totalPending === 0}
+            >
+              {bulkSaving
+                ? 'Sending...'
+                : totalPending > 0
+                  ? `Send all to Schoology (${totalPending})`
+                  : 'Send all to Schoology'}
+            </button>
+            {!bulkSaving && totalPending > 0 && (
+              <span className="text-sm text-muted">
+                {totalPending} student{totalPending !== 1 ? 's' : ''} with unsaved changes
+              </span>
+            )}
+            {bulkResult && (
+              <span className="text-sm text-muted">{bulkResult}</span>
+            )}
+          </div>
+        </>
       )}
     </div>
   );

--- a/client/src/pages/AssessmentSummaryPage.jsx
+++ b/client/src/pages/AssessmentSummaryPage.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { getMasteryForAssignment, syncMasteryForAssignment, writeMasteryScores, writeMasteryComment, createFlag, deleteFlag } from '../services/api.js';
+import { getMasteryForAssignment, syncMasteryForAssignment, writeMasteryScores, writeMasteryComment, sendAllGrades, createFlag, deleteFlag } from '../services/api.js';
 import { draftKey, readDraft, writeDraft, clearDraft, draftBaseline } from '../lib/assessmentDraft.js';
 
 const LEVELS = ['ED', 'EX', 'D', 'EM', 'IE'];
@@ -45,7 +45,7 @@ function normalizePastedText(text) {
 
 // ── Per-student rubric card ──────────────────────────────────────────────────
 
-export function StudentRubricCard({ student, topics, courseId, assignmentId, assignmentRow, onSaved, onPendingChange, registerSaver, unregisterSaver }) {
+export function StudentRubricCard({ student, topics, courseId, assignmentId, assignmentRow, onSaved, onPendingChange, registerCard, unregisterCard }) {
   const loadedDisplay = student.comment_status === 1;
   const storageKey = draftKey(courseId, assignmentId, student.enrollment_id);
   // Signature of the synced Schoology values this card was rendered against.
@@ -136,11 +136,15 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
 
   // ── Page-level "Send all" wiring (#51) ──────────────────────────────────
   // Report this card's pending state up so the page bar can count unsaved
-  // cards and enable/disable. Register an imperative saver the bar invokes.
-  // saveRef always points at the latest handleSave closure so the registered
-  // thunk saves current state, not a stale snapshot.
-  const saveRef = useRef(null);
-  saveRef.current = handleSave;
+  // cards and enable/disable. Register two callbacks the page's batched
+  // "Send all" uses: getEntry() returns this card's request entry + in-place
+  // patch (or null when nothing is unsaved), and applyResult(ok) updates the
+  // card's own badge/pending state after the batch lands. The refs always point
+  // at the latest closures so the page reads current state, not a stale one.
+  const entryRef = useRef(null);
+  entryRef.current = buildSendEntry;
+  const applyRef = useRef(null);
+  applyRef.current = applySendResult;
 
   useEffect(() => {
     onPendingChange?.(student.schoology_uid, hasPendingChanges);
@@ -148,9 +152,12 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
 
   useEffect(() => {
     const uid = student.schoology_uid;
-    registerSaver?.(uid, () => saveRef.current());
-    return () => unregisterSaver?.(uid);
-  }, [student.schoology_uid, registerSaver, unregisterSaver]);
+    registerCard?.(uid, {
+      getEntry: () => entryRef.current(),
+      applyResult: (ok) => applyRef.current(ok),
+    });
+    return () => unregisterCard?.(uid);
+  }, [student.schoology_uid, registerCard, unregisterCard]);
 
   // Apply a new comment value, auto-flipping the display toggle ON the first
   // time a virgin record's comment goes empty → non-empty. Shared by the
@@ -180,28 +187,76 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
     }
   }
 
+  // Schoology's /observations endpoint replaces the entire observation set for
+  // this enrollment+material — partial payloads wipe untouched topics. So build
+  // gradeInfo from every aligned topic, with pending changes merged over the
+  // current scores. Numeric grade strings ("100"/"75"/...) only: the DB stores
+  // letter codes, but Schoology silently drops them — always map via LEVEL_POINTS.
+  function buildGradeInfo() {
+    const gradeInfo = {};
+    for (const t of topics) {
+      const level = pending[t.id] ?? student.scores[t.id]?.grade;
+      if (level == null) continue;
+      const points = LEVEL_POINTS[level];
+      if (points == null) continue;
+      gradeInfo[t.id] = { grade: String(points), gradingScaleId: 21337256 };
+    }
+    return gradeInfo;
+  }
+
+  // Post-save score map (pending merged over current), keeping the DB's letter
+  // codes — used to patch this card in place after save, no reload/unmount (#50).
+  function buildSavedScores() {
+    const newScores = {};
+    for (const t of topics) {
+      const level = pending[t.id] ?? student.scores[t.id]?.grade;
+      if (level == null) continue;
+      newScores[t.id] = { points: LEVEL_POINTS[level], grade: level };
+    }
+    return newScores;
+  }
+
+  // This card's batched "Send all" entry + its in-place patch, or null when
+  // nothing is unsaved. Same writes as handleSave, expressed as data for the
+  // page to collapse into one request (#51).
+  function buildSendEntry() {
+    const hasScoreChanges = Object.keys(pending).length > 0;
+    const hasCommentChange = comment !== (student.grade_comment || '');
+    const hasDisplayChange = display !== loadedDisplay;
+    if (!hasScoreChanges && !hasCommentChange && !hasDisplayChange) return null;
+    return {
+      entry: {
+        uid: student.schoology_uid,
+        enrollmentId: student.enrollment_id,
+        assignmentId,
+        scores: (hasScoreChanges && assignmentRow) ? {
+          gradeInfo: buildGradeInfo(),
+          gradingPeriodId: assignmentRow.mastery_grading_period_id,
+          gradingCategoryId: assignmentRow.mastery_grading_category_id,
+        } : null,
+        comment: (hasCommentChange || hasDisplayChange) ? { comment, commentStatus: display } : null,
+      },
+      patch: { scores: buildSavedScores(), grade_comment: comment, comment_status: display ? 1 : null },
+    };
+  }
+
+  // Update this card's own UI after the page's batch lands. The page applies the
+  // in-place data patch itself (handleCardSaved) — here we only own the badge,
+  // pending reset, and draft clear (mirrors handleSave's success/error tail).
+  function applySendResult(ok) {
+    if (ok) {
+      setSaveResult('saved');
+      setPending({});
+      clearDraft(storageKey);
+    } else {
+      setSaveResult('error: send failed');
+    }
+  }
+
   async function handleSave() {
     setSaving(true);
     setSaveResult(null);
     try {
-      // Schoology's /observations endpoint replaces the entire observation set
-      // for this enrollment+material — partial payloads wipe untouched topics.
-      // Build gradeInfo from every aligned topic, with pending changes merged over
-      // the current scores.
-      const gradeInfo = {};
-      for (const t of topics) {
-        const pendingLevel = pending[t.id];
-        const currentGrade = student.scores[t.id]?.grade;
-        const level = pendingLevel ?? currentGrade;
-        if (level == null) continue;
-        // Schoology expects numeric grade strings ("100"/"75"/...). DB stores
-        // letter codes ("ED"/"EX"/...). Always map through LEVEL_POINTS so the
-        // payload is uniformly numeric — Schoology silently drops letter codes.
-        const points = LEVEL_POINTS[level];
-        if (points == null) continue;
-        gradeInfo[t.id] = { grade: String(points), gradingScaleId: 21337256 };
-      }
-
       const hasScoreChanges = Object.keys(pending).length > 0;
       const hasCommentChange = comment !== (student.grade_comment || '');
       const hasDisplayChange = display !== loadedDisplay;
@@ -210,7 +265,7 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
         await writeMasteryScores(courseId, {
           enrollmentId: student.enrollment_id,
           assignmentId,
-          gradeInfo,
+          gradeInfo: buildGradeInfo(),
           gradingPeriodId: assignmentRow.mastery_grading_period_id,
           gradingCategoryId: assignmentRow.mastery_grading_category_id,
         });
@@ -224,22 +279,13 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
           commentStatus: display,
         });
       }
-      // Build the post-save score map (pending merged over current) so the page
-      // can patch this one student in place — no full reload, no card unmount
-      // flash (#50). Mirrors the gradeInfo loop but keeps the DB's letter codes.
-      const newScores = {};
-      for (const t of topics) {
-        const level = pending[t.id] ?? student.scores[t.id]?.grade;
-        if (level == null) continue;
-        newScores[t.id] = { points: LEVEL_POINTS[level], grade: level };
-      }
       setSaveResult('saved');
       setPending({});
       // Explicit clear: the card stays mounted now, but the write effect runs
       // asynchronously — clear here so a fast bulk run can't race a stale key.
       clearDraft(storageKey);
       onSaved?.(student.schoology_uid, {
-        scores: newScores,
+        scores: buildSavedScores(),
         grade_comment: comment,
         comment_status: display ? 1 : null,
       });
@@ -327,7 +373,10 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
       border: bothSignals ? '1px solid var(--resubmit-ring)' : '1px solid var(--border)',
       boxShadow: bothSignals ? '0 0 0 2px var(--badge-resubmit-bg)' : 'none',
       borderRadius: 10,
-      background: 'var(--card-bg)', overflow: 'hidden',
+      // overflow visible so the oversized avatar can pop past the header band
+      // (top and bottom) without being clipped. Only the header has a corner-
+      // reaching background, so we round its top corners to keep the card edge.
+      background: 'var(--card-bg)', overflow: 'visible',
       marginBottom: '1rem',
     }}>
       {/* Student header */}
@@ -335,22 +384,32 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
         padding: '0.6rem 1rem', background: 'var(--bg-subtle)',
         display: 'flex', alignItems: 'center', gap: '0.75rem',
         borderBottom: '1px solid var(--border)',
+        borderTopLeftRadius: 10, borderTopRightRadius: 10,
       }}>
         {/* Student photo (#24) — mirrors the course-roster avatar pattern, with
             an initials fallback when no picture has synced. */}
+        {/* Sized larger than the header band and given negative vertical margins
+            so the ring extrudes past the header's bottom border onto the card
+            body — the white border + shadow make the avatar pop. */}
         {student.picture_url ? (
           <img
             src={student.picture_url}
             alt=""
-            style={{ width: 32, height: 32, borderRadius: '50%', objectFit: 'cover', display: 'block', flexShrink: 0 }}
+            style={{
+              width: 78, height: 78, borderRadius: '50%', objectFit: 'cover',
+              display: 'block', flexShrink: 0, marginTop: -28, marginBottom: -28,
+              border: '3px solid var(--card-bg)', boxShadow: '0 2px 6px rgba(0,0,0,0.18)',
+            }}
             onError={e => { e.currentTarget.style.display = 'none'; }}
           />
         ) : (
           <div style={{
-            width: 32, height: 32, borderRadius: '50%', flexShrink: 0,
+            width: 78, height: 78, borderRadius: '50%', flexShrink: 0,
+            marginTop: -28, marginBottom: -28,
+            border: '3px solid var(--card-bg)', boxShadow: '0 2px 6px rgba(0,0,0,0.18)',
             background: 'var(--bg-subtle)', display: 'flex',
             alignItems: 'center', justifyContent: 'center',
-            fontSize: '0.75rem', color: 'var(--text-muted)', fontWeight: 600,
+            fontSize: '1.5rem', color: 'var(--text-muted)', fontWeight: 600,
           }}>
             {(student.first_name?.[0] || '')}{(student.last_name?.[0] || '')}
           </div>
@@ -692,11 +751,12 @@ export default function AssessmentSummaryPage() {
   const [refreshResult, setRefreshResult] = useState(null);
 
   // "Send all" bar state (#51). pendingByUid maps each card's uid → true while
-  // it has unsaved changes; saversRef holds each card's imperative save thunk.
+  // it has unsaved changes; cardsRef holds each card's { getEntry, applyResult }
+  // so the batch can collect entries and report results back per card.
   const [pendingByUid, setPendingByUid] = useState({});
   const [bulkSaving, setBulkSaving] = useState(false);
   const [bulkResult, setBulkResult] = useState(null);
-  const saversRef = useRef({});
+  const cardsRef = useRef({});
 
   // Patch a single student in place after its card saves, instead of reloading
   // the whole page (#50). Avoids the "Loading..." flash that unmounted every
@@ -719,9 +779,9 @@ export default function AssessmentSummaryPage() {
       return next;
     });
   }, []);
-  const registerSaver = useCallback((uid, fn) => { saversRef.current[uid] = fn; }, []);
-  const unregisterSaver = useCallback((uid) => {
-    delete saversRef.current[uid];
+  const registerCard = useCallback((uid, handlers) => { cardsRef.current[uid] = handlers; }, []);
+  const unregisterCard = useCallback((uid) => {
+    delete cardsRef.current[uid];
     setPendingByUid(prev => {
       if (!prev[uid]) return prev;
       const next = { ...prev }; delete next[uid]; return next;
@@ -735,17 +795,35 @@ export default function AssessmentSummaryPage() {
     if (uids.length === 0) return;
     setBulkSaving(true);
     setBulkResult(null);
-    let ok = 0, fail = 0;
+
+    // Collect each pending card's request entry + its in-place patch, then send
+    // the whole set in one batched request (#51) — one browser session for all
+    // score writes + one bulk comment PUT, instead of a per-card loop.
+    const items = [];
     for (const uid of uids) {
-      const save = saversRef.current[uid];
-      if (!save) continue;
-      // Sequential: each card writes to Schoology; avoid hammering the API and
-      // keep per-card Saved/error badges legible as they land.
-      const success = await save();
-      if (success) ok++; else fail++;
+      const built = cardsRef.current[uid]?.getEntry();
+      if (built) items.push({ uid, ...built });
     }
-    setBulkResult(`Sent ${ok} grade${ok !== 1 ? 's' : ''}${fail ? `, ${fail} failed` : ''}`);
-    setBulkSaving(false);
+    if (items.length === 0) { setBulkSaving(false); return; }
+
+    try {
+      const { results } = await sendAllGrades(courseId, items.map(i => i.entry));
+      const okByUid = new Map((results || []).map(r => [r.uid, r.ok]));
+      let ok = 0, fail = 0;
+      for (const i of items) {
+        const success = okByUid.get(i.uid) ?? false;
+        cardsRef.current[i.uid]?.applyResult(success);
+        if (success) { handleCardSaved(i.uid, i.patch); ok++; } else { fail++; }
+      }
+      setBulkResult(`Sent ${ok} grade${ok !== 1 ? 's' : ''}${fail ? `, ${fail} failed` : ''}`);
+    } catch (err) {
+      // All-or-nothing: a non-2xx (incl. the 502 abort) rejects here — mark every
+      // card failed and leave them pending so a retry is one click away.
+      for (const i of items) cardsRef.current[i.uid]?.applyResult(false);
+      setBulkResult(`Error: ${err.message}`);
+    } finally {
+      setBulkSaving(false);
+    }
   }
 
   function load() {
@@ -835,8 +913,8 @@ export default function AssessmentSummaryPage() {
               assignmentRow={assignment}
               onSaved={handleCardSaved}
               onPendingChange={handlePendingChange}
-              registerSaver={registerSaver}
-              unregisterSaver={unregisterSaver}
+              registerCard={registerCard}
+              unregisterCard={unregisterCard}
             />
           ))}
 

--- a/client/src/pages/AssessmentSummaryPage.test.jsx
+++ b/client/src/pages/AssessmentSummaryPage.test.jsx
@@ -3,13 +3,14 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { useState } from 'react';
 import AssessmentSummaryPage, { StudentRubricCard } from './AssessmentSummaryPage.jsx';
-import { createFlag, deleteFlag, writeMasteryScores, writeMasteryComment, getMasteryForAssignment } from '../services/api.js';
+import { createFlag, deleteFlag, writeMasteryScores, writeMasteryComment, sendAllGrades, getMasteryForAssignment } from '../services/api.js';
 
 vi.mock('../services/api.js', () => ({
   getMasteryForAssignment: vi.fn(),
   syncMasteryForAssignment: vi.fn(),
   writeMasteryScores: vi.fn().mockResolvedValue({}),
   writeMasteryComment: vi.fn().mockResolvedValue({}),
+  sendAllGrades: vi.fn().mockResolvedValue({ results: [] }),
   createFlag: vi.fn().mockResolvedValue({ id: 99, flag_reason: 'Check citations' }),
   deleteFlag: vi.fn().mockResolvedValue({ success: true }),
 }));
@@ -432,8 +433,9 @@ describe('AssessmentSummaryPage — Send all bar (#51)', () => {
     expect(btn).toBeDisabled();
   });
 
-  it('counts pending cards and pushes each one on click', async () => {
+  it('counts pending cards and sends them in one batched request', async () => {
     getMasteryForAssignment.mockResolvedValue(makeData());
+    sendAllGrades.mockResolvedValue({ results: [{ uid: 'uid-1', ok: true }] });
     renderPage();
     await screen.findByRole('button', { name: /send all to schoology/i });
 
@@ -444,7 +446,35 @@ describe('AssessmentSummaryPage — Send all bar (#51)', () => {
     expect(btn).toBeEnabled();
 
     fireEvent.click(btn);
-    await waitFor(() => expect(writeMasteryScores).toHaveBeenCalledTimes(1));
+
+    // One batched call, not a per-card loop.
+    await waitFor(() => expect(sendAllGrades).toHaveBeenCalledTimes(1));
+    expect(writeMasteryScores).not.toHaveBeenCalled();
+    const [courseId, entries] = sendAllGrades.mock.calls[0];
+    expect(courseId).toBe('4');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].uid).toBe('uid-1');
+    expect(entries[0].scores.gradeInfo.t1.grade).toBe('50');
     expect(await screen.findByText(/Sent 1 grade/)).toBeInTheDocument();
+  });
+
+  it('batches multiple pending cards into a single request and marks each saved', async () => {
+    getMasteryForAssignment.mockResolvedValue(makeData());
+    sendAllGrades.mockResolvedValue({ results: [{ uid: 'uid-1', ok: true }, { uid: 'uid-2', ok: true }] });
+    renderPage();
+    await screen.findByRole('button', { name: /send all to schoology/i });
+
+    fireEvent.click(screen.getAllByTitle('Set Topic 1 to Developing')[0]);
+    fireEvent.click(screen.getAllByTitle('Set Topic 1 to Developing')[1]);
+
+    const btn = await screen.findByRole('button', { name: /send all to schoology \(2\)/i });
+    fireEvent.click(btn);
+
+    await waitFor(() => expect(sendAllGrades).toHaveBeenCalledTimes(1));
+    const [, entries] = sendAllGrades.mock.calls[0];
+    expect(entries).toHaveLength(2);
+    expect(await screen.findByText(/Sent 2 grades/)).toBeInTheDocument();
+    // Both cards show their per-card saved badge after the batch.
+    await waitFor(() => expect(screen.getAllByText('Saved ✓')).toHaveLength(2));
   });
 });

--- a/client/src/pages/AssessmentSummaryPage.test.jsx
+++ b/client/src/pages/AssessmentSummaryPage.test.jsx
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { useState } from 'react';
-import { StudentRubricCard } from './AssessmentSummaryPage.jsx';
-import { createFlag, deleteFlag, writeMasteryScores, writeMasteryComment } from '../services/api.js';
+import AssessmentSummaryPage, { StudentRubricCard } from './AssessmentSummaryPage.jsx';
+import { createFlag, deleteFlag, writeMasteryScores, writeMasteryComment, getMasteryForAssignment } from '../services/api.js';
 
 vi.mock('../services/api.js', () => ({
   getMasteryForAssignment: vi.fn(),
@@ -77,9 +77,8 @@ describe('StudentRubricCard draft persistence', () => {
   });
 
   it('clears the stored draft after a successful save', async () => {
-    // The real page unmounts every card while it reloads after a save (it
-    // renders a global "Loading..." view). Reproduce that teardown here so
-    // the test exercises the production path.
+    // The card stays mounted after a save now (#50), but unmount it here anyway
+    // to prove the draft is cleared regardless of whether the card lives on.
     function SaveHarness() {
       const [mounted, setMounted] = useState(true);
       if (!mounted) return null;
@@ -365,5 +364,87 @@ describe('StudentRubricCard — re-submit requested toggle', () => {
   it('does not show the Resubmitted pill when student.resubmitted is false', () => {
     renderCard({ student: { ...makeStudent(), resubmitted: false } });
     expect(screen.queryByText(/^↩ Resubmitted$/)).not.toBeInTheDocument();
+  });
+});
+
+describe('StudentRubricCard — student photo (#24)', () => {
+  it('renders the student photo when picture_url is present', () => {
+    renderCard({ student: { ...makeStudent(), picture_url: 'https://schoology/p.jpg' } });
+    const img = document.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img.getAttribute('src')).toBe('https://schoology/p.jpg');
+  });
+
+  it('falls back to initials when there is no picture_url', () => {
+    renderCard(); // Ada Lovelace, no photo
+    expect(document.querySelector('img')).toBeNull();
+    expect(screen.getByText('AL')).toBeInTheDocument();
+  });
+});
+
+describe('StudentRubricCard — in-place save (#50)', () => {
+  it('reports saved values up via onSaved(uid, patch) instead of forcing a reload', async () => {
+    const onSaved = vi.fn();
+    renderCard({ onSaved });
+
+    fireEvent.click(screen.getByTitle('Set Topic 1 to Developing'));
+    fireEvent.change(screen.getByPlaceholderText(/Teacher comment/i), {
+      target: { value: 'nice work' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Update Schoology' }));
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+    const [uid, patch] = onSaved.mock.calls[0];
+    expect(uid).toBe('uid-1');
+    expect(patch.scores.t1).toEqual({ points: 50, grade: 'D' });
+    expect(patch.grade_comment).toBe('nice work');
+    // Card stays mounted — the success badge is still on screen.
+    expect(await screen.findByText('Saved ✓')).toBeInTheDocument();
+  });
+});
+
+describe('AssessmentSummaryPage — Send all bar (#51)', () => {
+  function makeData() {
+    return {
+      assignment: { id: 50, schoology_assignment_id: '8', title: 'Quiz', mastery_grading_period_id: 1, mastery_grading_category_id: 2 },
+      topics: TOPICS,
+      students: [
+        { ...makeStudent(), id: 1, schoology_uid: 'uid-1', last_name: 'Lovelace', enrollment_id: 'enr-1' },
+        { ...makeStudent(), id: 2, schoology_uid: 'uid-2', first_name: 'Alan', last_name: 'Turing', enrollment_id: 'enr-2' },
+      ],
+    };
+  }
+
+  function renderPage() {
+    return render(
+      <MemoryRouter initialEntries={['/course/4/assessment/8']}>
+        <Routes>
+          <Route path="/course/:id/assessment/:assignmentId" element={<AssessmentSummaryPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+  }
+
+  it('disables Send all when no card has unsaved changes', async () => {
+    getMasteryForAssignment.mockResolvedValue(makeData());
+    renderPage();
+    const btn = await screen.findByRole('button', { name: /send all to schoology/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('counts pending cards and pushes each one on click', async () => {
+    getMasteryForAssignment.mockResolvedValue(makeData());
+    renderPage();
+    await screen.findByRole('button', { name: /send all to schoology/i });
+
+    // Make a pending change on the first card only.
+    fireEvent.click(screen.getAllByTitle('Set Topic 1 to Developing')[0]);
+
+    const btn = await screen.findByRole('button', { name: /send all to schoology \(1\)/i });
+    expect(btn).toBeEnabled();
+
+    fireEvent.click(btn);
+    await waitFor(() => expect(writeMasteryScores).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText(/Sent 1 grade/)).toBeInTheDocument();
   });
 });

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -151,6 +151,7 @@ export const syncMasteryForAssignment = (courseId, assignmentId) => request(`/ma
 export const writeMasteryScores = (courseId, data) => request(`/mastery/${courseId}/write`, { method: 'POST', body: JSON.stringify(data) });
 export const writeMasteryComment = (courseId, data) => request(`/mastery/${courseId}/write-comment`, { method: 'POST', body: JSON.stringify(data) });
 export const writeMasteryOverride = (courseId, data) => request(`/mastery/${courseId}/override`, { method: 'POST', body: JSON.stringify(data) });
+export const sendAllGrades = (courseId, entries) => request(`/mastery/${courseId}/send-all`, { method: 'POST', body: JSON.stringify({ entries }) });
 
 // Import
 export const uploadPowerSchoolCSV = (file) => {

--- a/server/routes/mastery.js
+++ b/server/routes/mastery.js
@@ -411,6 +411,7 @@ router.get('/:courseId/assignment/:assignmentId', (req, res) => {
   const targeted = assignmentRow && assignmentRow.num_assignees && assignmentRow.num_assignees > 0;
   const students = db.prepare(targeted ? `
     SELECT s.id, s.schoology_uid, s.first_name, s.last_name, s.preferred_name, s.preferred_name_teacher,
+           s.picture_url,
            e.schoology_enrolment_id AS enrollment_id
     FROM students s
     JOIN enrolments e ON e.student_id = s.id
@@ -419,6 +420,7 @@ router.get('/:courseId/assignment/:assignmentId', (req, res) => {
     ORDER BY s.last_name, s.first_name
   ` : `
     SELECT s.id, s.schoology_uid, s.first_name, s.last_name, s.preferred_name, s.preferred_name_teacher,
+           s.picture_url,
            e.schoology_enrolment_id AS enrollment_id
     FROM students s
     JOIN enrolments e ON e.student_id = s.id

--- a/server/routes/mastery.js
+++ b/server/routes/mastery.js
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { getDb } from '../db/index.js';
-import { hasMasterySession, syncMasteryForCourse, syncMasteryForAssignment, writeMasteryScores, writeMasteryOverride, getMasteryForCourse, getRubricScoresForStudent, interactiveLogin } from '../services/masterySync.js';
+import { hasMasterySession, syncMasteryForCourse, syncMasteryForAssignment, writeMasteryScores, writeMasteryScoresBatch, writeMasteryOverride, getMasteryForCourse, getRubricScoresForStudent, interactiveLogin } from '../services/masterySync.js';
 import { pushGradeComments, getSectionGrades } from '../services/schoology.js';
 import { isResubmitted } from '../lib/resubmission.js';
 
@@ -630,6 +630,124 @@ router.post('/:courseId/write-comment', async (req, res) => {
   } catch (err) {
     console.error('[mastery write-comment] Error:', err);
     res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /api/mastery/:courseId/send-all — batched bulk send (#51).
+// Collapses the assessment-page "Send all" loop into one request: all rubric
+// score writes go through a single browser session (writeMasteryScoresBatch),
+// then a single fresh GET + one bulk comment PUT covers every comment. The
+// batch is all-or-nothing — any failure aborts before anything is mirrored
+// locally, and a retry is idempotent (observations replace; the comment PUT
+// echoes each fresh grade so it never wipes a score, see #46).
+router.post('/:courseId/send-all', async (req, res) => {
+  const { courseId } = req.params;
+  const { entries } = req.body;
+
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return res.status(400).json({ error: 'entries[] is required' });
+  }
+
+  const db = getDb();
+  const courseRow = db.prepare('SELECT schoology_section_id FROM courses WHERE id = ?').get(courseId);
+  if (!courseRow) return res.status(404).json({ error: 'Course not found' });
+  const sectionId = courseRow.schoology_section_id;
+
+  const scoreEntries = entries.filter(e => e.scores);
+  const commentEntries = entries.filter(e => e.comment);
+
+  try {
+    // 1. All rubric scores in one browser session.
+    if (scoreEntries.length > 0) {
+      await writeMasteryScoresBatch({
+        sectionId,
+        entries: scoreEntries.map(e => ({
+          enrollmentId: e.enrollmentId,
+          assignmentId: e.assignmentId,
+          gradeInfo: e.scores.gradeInfo,
+          gradingPeriodId: e.scores.gradingPeriodId,
+          gradingCategoryId: e.scores.gradingCategoryId,
+        })),
+      });
+    }
+
+    // 2. One fresh read of the section grades, reflecting the writes above, so
+    //    each comment PUT can echo the current grade/exception (#46 safety).
+    let freshByKey = new Map();
+    if (commentEntries.length > 0) {
+      const allGrades = await getSectionGrades(sectionId);
+      for (const g of allGrades) {
+        freshByKey.set(`${g.assignment_id}::${g.enrollment_id}`, g);
+      }
+
+      const payloads = commentEntries.map(e => {
+        const fresh = freshByKey.get(`${e.assignmentId}::${e.enrollmentId}`) || null;
+        const payload = {
+          assignment_id: String(e.assignmentId),
+          enrollment_id: String(e.enrollmentId),
+          comment: e.comment.comment || '',
+          comment_status: e.comment.commentStatus === false ? null : 1,
+        };
+        if (fresh && fresh.grade != null) payload.grade = String(fresh.grade);
+        if (fresh && fresh.exception != null) payload.exception = fresh.exception;
+        return payload;
+      });
+
+      await pushGradeComments(sectionId, payloads);
+    }
+
+    // 3. Mirror to the local DB — only now that every write above succeeded.
+    //    Scores → mastery_scores (like the single /write); comments → grades
+    //    with the echoed fresh score/exception/timestamp (like write-comment),
+    //    so the gradebook reflects the save without a full re-sync (#60).
+    const now = new Date().toISOString();
+    const POINTS_TO_LETTER = { 0: 'IE', 25: 'EM', 50: 'D', 75: 'EX', 100: 'ED' };
+    const upsertScore = db.prepare(`
+      INSERT INTO mastery_scores (student_uid, assignment_schoology_id, topic_id, points, grade, synced_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+      ON CONFLICT(student_uid, assignment_schoology_id, topic_id) DO UPDATE SET
+        points = excluded.points, grade = excluded.grade, synced_at = excluded.synced_at
+    `);
+    const upsertGrade = db.prepare(`
+      INSERT INTO grades (student_id, assignment_id, enrolment_id, score, exception, submitted_at, grade_comment, comment_status, synced_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(student_id, assignment_id) DO UPDATE SET
+        score = excluded.score, exception = excluded.exception, submitted_at = excluded.submitted_at,
+        grade_comment = excluded.grade_comment, comment_status = excluded.comment_status, synced_at = excluded.synced_at
+    `);
+
+    for (const e of scoreEntries) {
+      const studentRow = db.prepare(
+        'SELECT s.schoology_uid FROM students s JOIN enrolments en ON en.student_id = s.id WHERE en.schoology_enrolment_id = ?'
+      ).get(String(e.enrollmentId));
+      if (!studentRow) continue;
+      for (const [topicId, info] of Object.entries(e.scores.gradeInfo)) {
+        const points = Number(info.grade);
+        upsertScore.run(studentRow.schoology_uid, String(e.assignmentId), topicId, points, POINTS_TO_LETTER[points] ?? null, now);
+      }
+    }
+
+    for (const e of commentEntries) {
+      const studentRow = db.prepare(
+        'SELECT s.id FROM students s JOIN enrolments en ON en.student_id = s.id WHERE en.schoology_enrolment_id = ?'
+      ).get(String(e.enrollmentId));
+      const assignmentRow = db.prepare('SELECT id FROM assignments WHERE schoology_assignment_id = ?').get(String(e.assignmentId));
+      if (!studentRow || !assignmentRow) continue;
+      const fresh = freshByKey.get(`${e.assignmentId}::${e.enrollmentId}`) || null;
+      const commentStatusInt = e.comment.commentStatus === false ? null : 1;
+      upsertGrade.run(
+        studentRow.id, assignmentRow.id, String(e.enrollmentId),
+        fresh ? (fresh.grade ?? null) : null,
+        fresh ? (fresh.exception ?? 0) : 0,
+        fresh ? (Number(fresh.timestamp) || 0) : 0,
+        e.comment.comment || '', commentStatusInt, now,
+      );
+    }
+
+    res.json({ results: entries.map(e => ({ uid: e.uid, ok: true })) });
+  } catch (err) {
+    console.error('[mastery send-all] Error:', err);
+    res.status(502).json({ error: err.message, results: entries.map(e => ({ uid: e.uid, ok: false })) });
   }
 });
 

--- a/server/routes/mastery.test.js
+++ b/server/routes/mastery.test.js
@@ -12,6 +12,7 @@ vi.mock('../services/masterySync.js', () => ({
   syncMasteryForCourse: vi.fn(),
   syncMasteryForAssignment: vi.fn(),
   writeMasteryScores: vi.fn(),
+  writeMasteryScoresBatch: vi.fn(),
   writeMasteryOverride: vi.fn(),
   getMasteryForCourse: vi.fn(),
   getRubricScoresForStudent: vi.fn(),
@@ -24,7 +25,7 @@ vi.mock('../services/schoology.js', () => ({
 
 import router from './mastery.js';
 import { getDb } from '../db/index.js';
-import { getMasteryForCourse } from '../services/masterySync.js';
+import { getMasteryForCourse, writeMasteryScoresBatch } from '../services/masterySync.js';
 import { getSectionGrades, pushGradeComments } from '../services/schoology.js';
 
 function startServer() {
@@ -407,5 +408,159 @@ describe('POST /api/mastery/:courseId/write-comment — mirrors score to local D
     expect(row.score).toBe(88);
     expect(row.submitted_at).toBe(1779000000);
     expect(row.grade_comment).toBe('Comment only');
+  });
+});
+
+describe('POST /api/mastery/:courseId/send-all — batched bulk send (#51)', () => {
+  let courseId;
+  let adaId, bobId;
+  let assignmentRowId;
+
+  beforeEach(() => {
+    const db = getDb();
+    db.exec(
+      'DELETE FROM flags; DELETE FROM grades; DELETE FROM mastery_alignments; ' +
+      'DELETE FROM mastery_scores; DELETE FROM measurement_topics; ' +
+      'DELETE FROM reporting_categories; DELETE FROM assignment_assignees; ' +
+      'DELETE FROM enrolments; DELETE FROM assignments; ' +
+      'DELETE FROM students; DELETE FROM courses;'
+    );
+    courseId = db.prepare(
+      `INSERT INTO courses (schoology_section_id, course_name) VALUES ('sec-sa', 'Course')`
+    ).run().lastInsertRowid;
+    adaId = db.prepare(
+      `INSERT INTO students (schoology_uid, first_name, last_name) VALUES ('uid-ada', 'Ada', 'Lovelace')`
+    ).run().lastInsertRowid;
+    bobId = db.prepare(
+      `INSERT INTO students (schoology_uid, first_name, last_name) VALUES ('uid-bob', 'Bob', 'Babbage')`
+    ).run().lastInsertRowid;
+    db.prepare(`INSERT INTO enrolments (student_id, course_id, schoology_enrolment_id) VALUES (?, ?, 'enr-ada')`).run(adaId, courseId);
+    db.prepare(`INSERT INTO enrolments (student_id, course_id, schoology_enrolment_id) VALUES (?, ?, 'enr-bob')`).run(bobId, courseId);
+    assignmentRowId = db.prepare(
+      `INSERT INTO assignments (course_id, schoology_assignment_id, title) VALUES (?, 'sa-1', 'Project')`
+    ).run(courseId).lastInsertRowid;
+    // Topic the score mirror references (FK: mastery_scores.topic_id → measurement_topics.id).
+    db.prepare(`INSERT INTO measurement_topics (id, course_id, external_id, title) VALUES ('t1', ?, 'ART.1.1', 'Topic 1')`).run(courseId);
+
+    writeMasteryScoresBatch.mockReset();
+    writeMasteryScoresBatch.mockResolvedValue(undefined);
+    pushGradeComments.mockReset();
+    pushGradeComments.mockResolvedValue({ status: 207 });
+    getSectionGrades.mockReset();
+    getSectionGrades.mockResolvedValue([
+      { assignment_id: 'sa-1', enrollment_id: 'enr-ada', grade: 95, exception: 0, timestamp: 1779418446 },
+      { assignment_id: 'sa-1', enrollment_id: 'enr-bob', grade: 80, exception: 0, timestamp: 1779418400 },
+    ]);
+  });
+
+  function entry(uid, enrollmentId, { scores = true, comment = true } = {}) {
+    return {
+      uid,
+      enrollmentId,
+      assignmentId: 'sa-1',
+      scores: scores ? { gradeInfo: { 't1': { grade: '100', gradingScaleId: 21337256 } }, gradingPeriodId: 1, gradingCategoryId: 2 } : null,
+      comment: comment ? { comment: `note ${uid}`, commentStatus: true } : null,
+    };
+  }
+
+  test('writes all students with one score-batch call and one comment PUT', async () => {
+    const { status } = await post(`/api/mastery/${courseId}/send-all`, {
+      entries: [entry('uid-ada', 'enr-ada'), entry('uid-bob', 'enr-bob')],
+    });
+    expect(status).toBe(200);
+
+    // One batched score write covering both students…
+    expect(writeMasteryScoresBatch).toHaveBeenCalledTimes(1);
+    const batchArg = writeMasteryScoresBatch.mock.calls[0][0];
+    expect(batchArg.sectionId).toBe('sec-sa');
+    expect(batchArg.entries).toHaveLength(2);
+
+    // …and one bulk comment PUT covering both students.
+    expect(getSectionGrades).toHaveBeenCalledTimes(1);
+    expect(pushGradeComments).toHaveBeenCalledTimes(1);
+    const [, comments] = pushGradeComments.mock.calls[0];
+    expect(comments).toHaveLength(2);
+  });
+
+  test('echoes each student\'s fresh grade into its comment payload (#46 safety)', async () => {
+    await post(`/api/mastery/${courseId}/send-all`, {
+      entries: [entry('uid-ada', 'enr-ada'), entry('uid-bob', 'enr-bob')],
+    });
+
+    const [, comments] = pushGradeComments.mock.calls[0];
+    const ada = comments.find(c => c.enrollment_id === 'enr-ada');
+    const bob = comments.find(c => c.enrollment_id === 'enr-bob');
+    // Grades come from the single getSectionGrades read (95 / 80), echoed so the
+    // full-record-replace PUT doesn't wipe the score.
+    expect(ada.grade).toBe('95');
+    expect(bob.grade).toBe('80');
+    expect(ada.comment_status).toBe(1);
+  });
+
+  test('mirrors scores and comments into the local DB on success', async () => {
+    const db = getDb();
+    const { status } = await post(`/api/mastery/${courseId}/send-all`, {
+      entries: [entry('uid-ada', 'enr-ada'), entry('uid-bob', 'enr-bob')],
+    });
+    expect(status).toBe(200);
+
+    // mastery_scores mirrored per topic (points → letter, like the single /write).
+    const score = db.prepare(
+      `SELECT points, grade FROM mastery_scores WHERE student_uid = 'uid-ada' AND assignment_schoology_id = 'sa-1' AND topic_id = 't1'`
+    ).get();
+    expect(score.points).toBe(100);
+    expect(score.grade).toBe('ED');
+
+    // grades row mirrored with the fresh score + comment (like the single write-comment).
+    const grade = db.prepare(
+      `SELECT score, grade_comment, comment_status, submitted_at FROM grades
+       WHERE student_id = ? AND assignment_id = ?`
+    ).get(adaId, assignmentRowId);
+    expect(grade.score).toBe(95);
+    expect(grade.grade_comment).toBe('note uid-ada');
+    expect(grade.comment_status).toBe(1);
+    expect(grade.submitted_at).toBe(1779418446);
+  });
+
+  test('all-or-nothing: a score-batch failure aborts before comments and mirrors nothing', async () => {
+    const db = getDb();
+    writeMasteryScoresBatch.mockRejectedValue(new Error('session stale'));
+
+    const { status, body } = await post(`/api/mastery/${courseId}/send-all`, {
+      entries: [entry('uid-ada', 'enr-ada'), entry('uid-bob', 'enr-bob')],
+    });
+
+    expect(status).toBe(502);
+    expect(body.results.every(r => r.ok === false)).toBe(true);
+    // No comment PUT, and nothing mirrored locally.
+    expect(pushGradeComments).not.toHaveBeenCalled();
+    const scores = db.prepare(`SELECT COUNT(*) AS n FROM mastery_scores`).get();
+    expect(scores.n).toBe(0);
+    const grades = db.prepare(`SELECT COUNT(*) AS n FROM grades`).get();
+    expect(grades.n).toBe(0);
+  });
+
+  test('all-or-nothing: a fresh-grade read failure skips the comment PUT (no #46 wipe)', async () => {
+    getSectionGrades.mockRejectedValue(new Error('Schoology down'));
+
+    const { status } = await post(`/api/mastery/${courseId}/send-all`, {
+      entries: [entry('uid-ada', 'enr-ada'), entry('uid-bob', 'enr-bob')],
+    });
+
+    expect(status).toBe(502);
+    expect(pushGradeComments).not.toHaveBeenCalled();
+  });
+
+  test('score-only entries are excluded from the comment PUT', async () => {
+    await post(`/api/mastery/${courseId}/send-all`, {
+      entries: [
+        entry('uid-ada', 'enr-ada', { comment: false }), // scores only
+        entry('uid-bob', 'enr-bob'),                      // scores + comment
+      ],
+    });
+
+    const [, comments] = pushGradeComments.mock.calls[0];
+    expect(comments).toHaveLength(1);
+    expect(comments[0].enrollment_id).toBe('enr-bob');
   });
 });

--- a/server/services/masterySync.js
+++ b/server/services/masterySync.js
@@ -768,77 +768,135 @@ export async function writeMasteryScores({
   gradingPeriodId,
   gradingCategoryId,
 }) {
-  let { browser, page } = await openPage();
-
+  const { browser, page } = await openMasterySession(sectionId);
   try {
-    // Navigate to the course to establish session context
-    await page.goto(`${SCHOOLOGY_BASE}/course/${sectionId}/district_mastery`, {
-      waitUntil: 'domcontentloaded',
+    return await postObservation(page, {
+      sectionId, enrollmentId, assignmentId, gradeInfo, gradingPeriodId, gradingCategoryId,
     });
-
-    // If session is stale we'll be on a login/SSO page — relogin then retry.
-    if (!checkLoggedIn(page)) {
-      console.log('[mastery write] session stale, opening browser for relogin');
-      await browser.close();
-      await interactiveLogin();
-      ({ browser, page } = await openPage());
-      await page.goto(`${SCHOOLOGY_BASE}/course/${sectionId}/district_mastery`, {
-        waitUntil: 'domcontentloaded',
-      });
-      if (!checkLoggedIn(page)) {
-        throw new Error('Still not logged in after relogin. Please run `npm run mastery:login` manually.');
-      }
-    }
-
-    const url = `${SCHOOLOGY_BASE}/iapi2/district-mastery/course/${sectionId}/observations`;
-    const payload = {
-      enrollmentId: Number(enrollmentId),
-      gradeInfo,
-      gradeItemId: Number(assignmentId),
-      isGradebook: true,
-      materialId: Number(assignmentId),
-      materialType: 'ASSIGNMENT',
-      maxPoints: 100,
-      overrideGrade: null,
-      isCollectedOnly: false,
-      gradingPeriodId: Number(gradingPeriodId),
-      gradingCategoryId: Number(gradingCategoryId),
-    };
-
-    const topicCount = Object.keys(gradeInfo).length;
-    console.log(`[mastery write] enrollment=${enrollmentId} assignment=${assignmentId} topics=${topicCount}`);
-    console.log(`[mastery write] gradeInfo=${JSON.stringify(gradeInfo)}`);
-
-    const result = await page.evaluate(async ({ url, payload }) => {
-      const csrf = {
-        token: window.Drupal?.settings?.s_common?.csrf_token,
-        key: window.Drupal?.settings?.s_common?.csrf_key,
-      };
-      if (!csrf.token || !csrf.key) {
-        return { status: 0, ok: false, body: 'CSRF token/key missing from Drupal.settings.s_common' };
-      }
-      const res = await fetch(url, {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          Accept: 'application/json',
-          'X-Requested-With': 'XMLHttpRequest',
-          'X-CSRF-Token': csrf.token,
-          'X-CSRF-Key': csrf.key,
-        },
-        body: JSON.stringify(payload),
-      });
-      const text = await res.text();
-      return { status: res.status, ok: res.ok, body: text };
-    }, { url, payload });
-
-    console.log(`[mastery write] response status=${result.status} body=${result.body.slice(0, 500)}`);
-    if (!result.ok) throw new Error(`HTTP ${result.status}: ${result.body}`);
-    return JSON.parse(result.body);
   } finally {
     await browser.close();
   }
+}
+
+/**
+ * Batched variant of {@link writeMasteryScores}: writes every entry's
+ * observation set through a *single* browser session — one Chromium launch and
+ * one navigation for the whole batch instead of per student. This is the
+ * dominant cost of the assessment-page "Send all", so collapsing N launches
+ * into one is the real win (the /observations endpoint is still posted
+ * per-enrollment; it is not known to accept multiple enrollments at once).
+ *
+ * Fail-fast / all-or-nothing: the first failed observation throws (after the
+ * browser is closed), and the caller treats the whole batch as failed so
+ * nothing downstream (comments, local mirror) runs. A retry is safe — the
+ * endpoint replaces the observation set for an enrollment.
+ *
+ * @param {object} params
+ * @param {string} params.sectionId — Schoology section ID
+ * @param {Array<{enrollmentId, assignmentId, gradeInfo, gradingPeriodId, gradingCategoryId}>} params.entries
+ */
+export async function writeMasteryScoresBatch({ sectionId, entries }) {
+  const { browser, page } = await openMasterySession(sectionId);
+  try {
+    const results = [];
+    for (const e of entries) {
+      const result = await postObservation(page, {
+        sectionId,
+        enrollmentId: e.enrollmentId,
+        assignmentId: e.assignmentId,
+        gradeInfo: e.gradeInfo,
+        gradingPeriodId: e.gradingPeriodId,
+        gradingCategoryId: e.gradingCategoryId,
+      });
+      results.push({ enrollmentId: e.enrollmentId, result });
+    }
+    return results;
+  } finally {
+    await browser.close();
+  }
+}
+
+/**
+ * Open a logged-in district-mastery page for a section. Navigates to the
+ * mastery gradebook to establish session + CSRF context; if the session is
+ * stale, runs an interactive relogin once and retries. Returns the live
+ * { browser, page } — the caller owns closing the browser.
+ */
+async function openMasterySession(sectionId) {
+  let { browser, page, context } = await openPage();
+  await page.goto(`${SCHOOLOGY_BASE}/course/${sectionId}/district_mastery`, {
+    waitUntil: 'domcontentloaded',
+  });
+
+  // If session is stale we'll be on a login/SSO page — relogin then retry.
+  if (!checkLoggedIn(page)) {
+    console.log('[mastery write] session stale, opening browser for relogin');
+    await browser.close();
+    await interactiveLogin();
+    ({ browser, page, context } = await openPage());
+    await page.goto(`${SCHOOLOGY_BASE}/course/${sectionId}/district_mastery`, {
+      waitUntil: 'domcontentloaded',
+    });
+    if (!checkLoggedIn(page)) {
+      throw new Error('Still not logged in after relogin. Please run `npm run mastery:login` manually.');
+    }
+  }
+  return { browser, page, context };
+}
+
+/**
+ * POST one enrollment's observation set to the district-mastery endpoint inside
+ * an already-logged-in page. The /observations call replaces the whole
+ * observation set for this enrollment+material, so callers must pass gradeInfo
+ * for every aligned topic. Throws on a non-OK response.
+ */
+async function postObservation(page, { sectionId, enrollmentId, assignmentId, gradeInfo, gradingPeriodId, gradingCategoryId }) {
+  const url = `${SCHOOLOGY_BASE}/iapi2/district-mastery/course/${sectionId}/observations`;
+  const payload = {
+    enrollmentId: Number(enrollmentId),
+    gradeInfo,
+    gradeItemId: Number(assignmentId),
+    isGradebook: true,
+    materialId: Number(assignmentId),
+    materialType: 'ASSIGNMENT',
+    maxPoints: 100,
+    overrideGrade: null,
+    isCollectedOnly: false,
+    gradingPeriodId: Number(gradingPeriodId),
+    gradingCategoryId: Number(gradingCategoryId),
+  };
+
+  const topicCount = Object.keys(gradeInfo).length;
+  console.log(`[mastery write] enrollment=${enrollmentId} assignment=${assignmentId} topics=${topicCount}`);
+  console.log(`[mastery write] gradeInfo=${JSON.stringify(gradeInfo)}`);
+
+  const result = await page.evaluate(async ({ url, payload }) => {
+    const csrf = {
+      token: window.Drupal?.settings?.s_common?.csrf_token,
+      key: window.Drupal?.settings?.s_common?.csrf_key,
+    };
+    if (!csrf.token || !csrf.key) {
+      return { status: 0, ok: false, body: 'CSRF token/key missing from Drupal.settings.s_common' };
+    }
+    const res = await fetch(url, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+        'X-CSRF-Token': csrf.token,
+        'X-CSRF-Key': csrf.key,
+      },
+      body: JSON.stringify(payload),
+    });
+    const text = await res.text();
+    return { status: res.status, ok: res.ok, body: text };
+  }, { url, payload });
+
+  console.log(`[mastery write] response status=${result.status} body=${result.body.slice(0, 500)}`);
+  if (!result.ok) throw new Error(`HTTP ${result.status}: ${result.body}`);
+  return JSON.parse(result.body);
 }
 
 /**


### PR DESCRIPTION
Three quick wins on the `/assessment/` grading page.

## #24 — Student photos on the grading page
- `server/routes/mastery.js`: add `picture_url` to both student queries (targeted + untargeted).
- `AssessmentSummaryPage.jsx`: 32px circular avatar in each `StudentRubricCard` header, with an initials fallback and `onError` hide — mirrors the existing `CoursePage` roster pattern. Photo data was already synced/stored; this just surfaces it.

## #50 — Send grade updates without a page refresh
- `handleSave` builds a patch (`{ scores, grade_comment, comment_status }`) from the just-saved values and reports it up via `onSaved(uid, patch)`.
- The page merges that patch into the single student in `data` (`handleCardSaved`) instead of calling `load()`. No `loading` flip, no card unmount — the saved card updates in place and keeps its "Saved ✓" badge. Removes the jarring full-page "Loading…" flash on every save during a grading run.

## #51 — Bulk "Send all to Schoology"
- Sticky bar at the page bottom showing a live count of cards with unsaved changes; enabled only when there's work.
- Cards report pending state up (`onPendingChange`) and register an imperative saver (`registerSaver`); clicking pushes each pending card **sequentially** (keeps per-card badges legible, avoids hammering the API), then reports `Sent N grades`.
- `handleSave` now returns success/failure so the bar can tally failures.

The three integrate: a bulk run saves each card, and each save patches itself in place via #50.

## Tests
- `AssessmentSummaryPage.test.jsx`: +5 (photo render/fallback, in-place `onSaved` patch, send-all bar count + push).
- Full client suite: 158 pass. Full server suite: 139 pass.

Not yet visually verified against live Schoology data — will manual-test before merge.

Closes #24
Closes #50
Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)