### PR TITLE
PrisMCP UI: surface reviewer suggestions on /assessment (Project A)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ data/imports/*.csv
 scripts/*-capture.json
 .superpowers/
 _tmp_*.mjs
+# Contains real student data (mockups + grading sample) — kept local, not committed
+docs/ui-design/PrisMCP-update/

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ data/imports/*.csv
 .playwright-mcp/
 scripts/*-capture.json
 .superpowers/
+.claude/worktrees/
 _tmp_*.mjs
 # Contains real student data (mockups + grading sample) — kept local, not committed
 docs/ui-design/PrisMCP-update/

--- a/client/src/lib/rubricSuggestions.js
+++ b/client/src/lib/rubricSuggestions.js
@@ -1,0 +1,38 @@
+// Resolve a free-form rubric_scores object to { [topicId]: level }.
+// Key match: topic external_id first, then title (both case-insensitive).
+// Value must be one of ED/EX/D/EM/IE; unmatched keys / out-of-set values are
+// dropped (logged, never blocking) — the overlay is best-effort (spec §5).
+const VALID_LEVELS = ['ED', 'EX', 'D', 'EM', 'IE'];
+
+export function resolveRubricScores(rubricScores, topics) {
+  const out = {};
+  if (!rubricScores || typeof rubricScores !== 'object') return out;
+  const byExternal = new Map();
+  const byTitle = new Map();
+  for (const t of topics) {
+    if (t.external_id) byExternal.set(String(t.external_id).toLowerCase(), t.id);
+    if (t.title) byTitle.set(String(t.title).toLowerCase(), t.id);
+  }
+  for (const [key, value] of Object.entries(rubricScores)) {
+    const k = String(key).toLowerCase();
+    const topicId = byExternal.get(k) ?? byTitle.get(k);
+    if (topicId == null) { console.debug('[rubricSuggestions] unresolved key', key); continue; }
+    if (!VALID_LEVELS.includes(value)) { console.debug('[rubricSuggestions] out-of-set value', key, value); continue; }
+    out[topicId] = value;
+  }
+  return out;
+}
+
+// Aggregate resolved suggestions across feedback rows into per-topic counts.
+// rows: array of { feedback_parsed: { rubric_scores } }.
+export function distributionByTopic(rows, topics) {
+  const dist = {};
+  for (const t of topics) dist[t.id] = { ED: 0, EX: 0, D: 0, EM: 0, IE: 0 };
+  for (const row of rows || []) {
+    const resolved = resolveRubricScores(row?.feedback_parsed?.rubric_scores, topics);
+    for (const [topicId, level] of Object.entries(resolved)) {
+      if (dist[topicId]) dist[topicId][level] += 1;
+    }
+  }
+  return dist;
+}

--- a/client/src/lib/rubricSuggestions.test.js
+++ b/client/src/lib/rubricSuggestions.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { resolveRubricScores, distributionByTopic } from './rubricSuggestions.js';
+
+const TOPICS = [
+  { id: 't1', external_id: 'X1', title: 'Ideation' },
+  { id: 't2', external_id: 'X2', title: 'UI Design' },
+];
+
+describe('resolveRubricScores', () => {
+  it('matches a key against external_id first', () => {
+    expect(resolveRubricScores({ X1: 'ED' }, TOPICS)).toEqual({ t1: 'ED' });
+  });
+  it('falls back to a case-insensitive title match', () => {
+    expect(resolveRubricScores({ 'ui design': 'EX' }, TOPICS)).toEqual({ t2: 'EX' });
+  });
+  it('ignores unresolvable keys and out-of-set values', () => {
+    expect(resolveRubricScores({ NOPE: 'ED', X1: '99', X2: 'EX' }, TOPICS)).toEqual({ t2: 'EX' });
+  });
+  it('returns an empty object for null/empty input', () => {
+    expect(resolveRubricScores(null, TOPICS)).toEqual({});
+    expect(resolveRubricScores({}, TOPICS)).toEqual({});
+  });
+});
+
+describe('distributionByTopic', () => {
+  it('counts resolved levels per topic across rows', () => {
+    const rows = [
+      { feedback_parsed: { rubric_scores: { X1: 'ED', X2: 'ED' } } },
+      { feedback_parsed: { rubric_scores: { X1: 'ED', X2: 'EX' } } },
+    ];
+    const dist = distributionByTopic(rows, TOPICS);
+    expect(dist.t1).toEqual({ ED: 2, EX: 0, D: 0, EM: 0, IE: 0 });
+    expect(dist.t2).toEqual({ ED: 1, EX: 1, D: 0, EM: 0, IE: 0 });
+  });
+});

--- a/client/src/lib/rubricSuggestions.test.js
+++ b/client/src/lib/rubricSuggestions.test.js
@@ -32,4 +32,10 @@ describe('distributionByTopic', () => {
     expect(dist.t1).toEqual({ ED: 2, EX: 0, D: 0, EM: 0, IE: 0 });
     expect(dist.t2).toEqual({ ED: 1, EX: 1, D: 0, EM: 0, IE: 0 });
   });
+
+  it('zero-initialises every topic for null or empty rows', () => {
+    const empty = { ED: 0, EX: 0, D: 0, EM: 0, IE: 0 };
+    expect(distributionByTopic(null, TOPICS)).toEqual({ t1: empty, t2: empty });
+    expect(distributionByTopic([], TOPICS)).toEqual({ t1: empty, t2: empty });
+  });
 });

--- a/client/src/pages/AssessmentSummaryPage.jsx
+++ b/client/src/pages/AssessmentSummaryPage.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { getMasteryForAssignment, getFeedbackForAssignment, getAssessmentAnalysis, syncMasteryForAssignment, writeMasteryScores, writeMasteryComment, sendAllGrades, createFlag, deleteFlag } from '../services/api.js';
 import { draftKey, readDraft, writeDraft, clearDraft, draftBaseline } from '../lib/assessmentDraft.js';
-import { resolveRubricScores } from '../lib/rubricSuggestions.js';
+import { resolveRubricScores, distributionByTopic } from '../lib/rubricSuggestions.js';
 
 const LEVELS = ['ED', 'EX', 'D', 'EM', 'IE'];
 const LEVEL_LABELS = {
@@ -888,7 +888,77 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
 // ── Reviewer Analysis drawer body ────────────────────────────────────────────
 
 function ReviewerAnalysisBody({ topics, feedbackRows, analysis }) {
-  return <div style={{ padding: '0.8rem' }} />;
+  const dist = distributionByTopic(feedbackRows, topics);
+  const noticings = analysis?.noticings || [];
+  const moderationNote = analysis?.moderation_note || null;
+
+  return (
+    <div style={{ padding: '0.8rem' }}>
+      {/* Proposed score distribution */}
+      <div style={{ marginBottom: '0.9rem' }}>
+        <div style={{
+          fontSize: '0.62rem', textTransform: 'uppercase', letterSpacing: '0.04em',
+          color: 'var(--text-muted)', fontWeight: 700, marginBottom: '0.15rem',
+        }}>
+          ✦ Proposed score distribution
+        </div>
+        <div style={{ fontSize: '0.6rem', color: '#9a90b8', marginBottom: '0.4rem' }}>
+          From the reviewer's suggested grades — not final entered scores.
+        </div>
+        {topics.map(t => {
+          const counts = dist[t.id] || { ED: 0, EX: 0, D: 0, EM: 0, IE: 0 };
+          const total = LEVELS.reduce((sum, l) => sum + counts[l], 0);
+          return (
+            <div key={t.id} style={{ display: 'flex', alignItems: 'center', gap: '0.45rem', marginBottom: '0.35rem' }}>
+              <div style={{ width: 70, fontSize: '0.64rem', fontWeight: 600, flexShrink: 0 }}>{t.title}</div>
+              <div style={{
+                flex: 1, display: 'flex', height: 18, borderRadius: 4,
+                overflow: 'hidden', border: '1px solid var(--border)',
+                background: 'var(--bg-subtle)',
+              }}>
+                {total > 0 && LEVELS.filter(l => counts[l] > 0).map(l => (
+                  <div key={l} style={{
+                    flex: counts[l], display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    fontSize: '0.56rem', fontWeight: 700, color: CELL_TEXT,
+                    background: CELL_COLORS[l].headerFill,
+                  }}>
+                    {counts[l]} {l}
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+        {moderationNote && (
+          <div style={{
+            fontSize: '0.62rem', color: '#92740f', background: '#fffbef',
+            border: '1px solid #f0dea8', borderRadius: 6, padding: '0.35rem 0.5rem',
+            marginTop: '0.45rem', lineHeight: 1.35,
+          }}>
+            ⚖️ {moderationNote}
+          </div>
+        )}
+      </div>
+
+      {/* Noticings */}
+      {noticings.length > 0 && (
+        <div>
+          <div style={{
+            fontSize: '0.62rem', textTransform: 'uppercase', letterSpacing: '0.04em',
+            color: 'var(--text-muted)', fontWeight: 700, marginBottom: '0.45rem',
+          }}>
+            Noticings
+          </div>
+          {noticings.map((n, i) => (
+            <div key={i} style={{ marginBottom: '0.55rem' }}>
+              <div style={{ fontWeight: 700, fontSize: '0.68rem', marginBottom: '0.12rem' }}>{n.title}</div>
+              <div style={{ fontSize: '0.66rem', lineHeight: 1.4, color: 'var(--text)' }}>{n.body}</div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }
 
 // ── Page ─────────────────────────────────────────────────────────────────────

--- a/client/src/pages/AssessmentSummaryPage.jsx
+++ b/client/src/pages/AssessmentSummaryPage.jsx
@@ -885,6 +885,12 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
   );
 }
 
+// ── Reviewer Analysis drawer body ────────────────────────────────────────────
+
+function ReviewerAnalysisBody({ topics, feedbackRows, analysis }) {
+  return <div style={{ padding: '0.8rem' }} />;
+}
+
 // ── Page ─────────────────────────────────────────────────────────────────────
 
 export default function AssessmentSummaryPage() {
@@ -896,6 +902,7 @@ export default function AssessmentSummaryPage() {
   const [refreshResult, setRefreshResult] = useState(null);
   const [feedbackByStudent, setFeedbackByStudent] = useState({});
   const [analysis, setAnalysis] = useState(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   // "Send all" bar state (#51). pendingByUid maps each card's uid → true while
   // it has unsaved changes; cardsRef holds each card's { getEntry, applyResult }
@@ -1010,6 +1017,7 @@ export default function AssessmentSummaryPage() {
   if (!data) return null;
 
   const { assignment, topics, students } = data;
+  const hasAnalysis = Object.keys(feedbackByStudent).length > 0 || !!analysis;
 
   const alignedTopics = topics;
 
@@ -1035,6 +1043,20 @@ export default function AssessmentSummaryPage() {
           </button>
           {refreshResult && (
             <span className="text-sm text-muted" style={{ fontSize: '0.75rem' }}>{refreshResult}</span>
+          )}
+          {hasAnalysis && (
+            <button
+              onClick={() => setDrawerOpen(true)}
+              title="Reviewer Analysis — not student-facing"
+              style={{
+                marginLeft: 'auto', border: '1px solid #c4b5fd', background: '#ede9fe',
+                color: '#6d28d9', borderRadius: 7, padding: '0.32rem 0.7rem',
+                fontSize: '0.74rem', fontWeight: 700, cursor: 'pointer',
+                display: 'inline-flex', alignItems: 'center', gap: '0.4rem',
+              }}
+            >
+              ✦ Reviewer Analysis
+            </button>
           )}
         </div>
       </div>
@@ -1089,6 +1111,46 @@ export default function AssessmentSummaryPage() {
             {bulkResult && (
               <span className="text-sm text-muted">{bulkResult}</span>
             )}
+          </div>
+        </>
+      )}
+
+      {drawerOpen && (
+        <>
+          <div
+            onClick={() => setDrawerOpen(false)}
+            style={{ position: 'fixed', inset: 0, background: 'rgba(20,20,30,0.28)', zIndex: 40 }}
+          />
+          <div style={{
+            position: 'fixed', top: 0, right: 0, height: '100%', width: 360,
+            background: 'var(--card-bg)', boxShadow: '-6px 0 20px rgba(0,0,0,0.16)',
+            zIndex: 50, overflowY: 'auto',
+          }}>
+            <div style={{
+              display: 'flex', alignItems: 'center', gap: '0.5rem',
+              padding: '0.65rem 0.85rem', borderBottom: '1px solid var(--border)',
+              background: 'var(--bg-subtle)', position: 'sticky', top: 0,
+            }}>
+              <span style={{ color: '#8b5cf6' }}>✦</span>
+              <span style={{ fontWeight: 700, fontSize: '0.84rem' }}>Reviewer Analysis</span>
+              <span style={{
+                fontSize: '0.58rem', background: 'var(--bg-subtle)', color: 'var(--text-muted)',
+                borderRadius: 5, padding: '1px 5px', fontWeight: 600,
+              }}>not student-facing</span>
+              <button
+                onClick={() => setDrawerOpen(false)}
+                aria-label="Close Reviewer Analysis"
+                style={{
+                  marginLeft: 'auto', cursor: 'pointer', color: 'var(--text-muted)',
+                  fontSize: '1.05rem', lineHeight: 1, border: 'none', background: 'none',
+                }}
+              >✕</button>
+            </div>
+            <ReviewerAnalysisBody
+              topics={topics}
+              feedbackRows={Object.values(feedbackByStudent)}
+              analysis={analysis?.analysis_parsed || null}
+            />
           </div>
         </>
       )}

--- a/client/src/pages/AssessmentSummaryPage.jsx
+++ b/client/src/pages/AssessmentSummaryPage.jsx
@@ -614,12 +614,11 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
                   </td>
                   {LEVELS.map(l => {
                     const c = CELL_COLORS[l];
-                    const pendingVal = pendingGrade;                 // pending[t.id] || null (from outer scope)
-                    const stagedRemoval = pendingVal === REMOVE && l === currentGrade;
-                    const isDraft = pendingVal !== REMOVE && l === pendingVal;
+                    const stagedRemoval = pendingGrade === REMOVE && l === currentGrade;
+                    const isDraft = pendingGrade !== REMOVE && l === pendingGrade;
                     // A synced final shows ONLY when nothing is pending for this topic (a pending
                     // draft on another cell overrides it → that old final renders Empty; spec §2).
-                    const isFinal = l === currentGrade && pendingVal == null;
+                    const isFinal = l === currentGrade && pendingGrade == null;
                     // Suggestion overlay inputs arrive in Slice 4; null-safe until then.
                     const isSuggested = suggestedLevel != null && l === suggestedLevel;
                     const hasTeacherMark = isFinal || isDraft || stagedRemoval;
@@ -633,26 +632,27 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
                       transition: 'all 0.1s',
                       color: CELL_TEXT,
                       background: 'var(--card-bg)',
+                      position: 'relative',
                     };
 
                     if (isFinal) {
                       cellStyle = {
                         ...cellStyle, background: c.headerFill,
                         border: `2px solid ${c.finalBorder}`, fontWeight: 700,
-                        position: 'relative', zIndex: 2,
+                        zIndex: 2,
                       };
                     } else if (isDraft) {
                       cellStyle = {
                         ...cellStyle, background: c.draftFill,
                         border: `2px solid ${c.draftBorder}`,
-                        position: 'relative', zIndex: 2,
+                        zIndex: 2,
                       };
                     } else if (stagedRemoval) {
                       // Removal marker (Slice 2): default bg, red dashed ring + ✕ glyph.
                       cellStyle = {
                         ...cellStyle, background: 'var(--card-bg)',
                         outline: '1.5px dashed #ef4444', outlineOffset: '-3px',
-                        position: 'relative', zIndex: 2,
+                        zIndex: 2,
                       };
                     }
 
@@ -661,9 +661,10 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
                     if (isSuggested) {
                       cellStyle = {
                         ...cellStyle,
-                        outline: stagedRemoval ? cellStyle.outline : `1px dashed ${SUGGEST.ring}`,
-                        outlineOffset: '-3px',
-                        position: 'relative', zIndex: 2,
+                        ...(stagedRemoval
+                          ? { outline: cellStyle.outline, outlineOffset: cellStyle.outlineOffset }
+                          : { outline: `1px dashed ${SUGGEST.ring}`, outlineOffset: '-3px' }),
+                        zIndex: 2,
                         ...(hasTeacherMark ? {} : { background: SUGGEST.fill }),
                       };
                     }
@@ -678,7 +679,7 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
                         title={`Set ${t.title} to ${LEVEL_LABELS[l]}`}
                       >
                         {showCode ? (
-                          <span style={{ fontWeight: isFinal ? 700 : 400, fontSize: '0.75rem', color: CELL_TEXT }}>
+                          <span style={{ fontSize: '0.75rem', color: CELL_TEXT }}>
                             {l}
                           </span>
                         ) : null}

--- a/client/src/pages/AssessmentSummaryPage.jsx
+++ b/client/src/pages/AssessmentSummaryPage.jsx
@@ -916,15 +916,18 @@ function ReviewerAnalysisBody({ topics, feedbackRows, analysis }) {
                 overflow: 'hidden', border: '1px solid var(--border)',
                 background: 'var(--bg-subtle)',
               }}>
-                {total > 0 && LEVELS.filter(l => counts[l] > 0).map(l => (
-                  <div key={l} style={{
-                    flex: counts[l], display: 'flex', alignItems: 'center', justifyContent: 'center',
-                    fontSize: '0.56rem', fontWeight: 700, color: CELL_TEXT,
-                    background: CELL_COLORS[l].headerFill,
-                  }}>
-                    {counts[l]} {l}
-                  </div>
-                ))}
+                {total > 0 && LEVELS.filter(l => counts[l] > 0).map(l => {
+                  const showLabel = counts[l] / total >= 0.12;
+                  return (
+                    <div key={l} title={`${counts[l]} ${l}`} style={{
+                      flex: counts[l], display: 'flex', alignItems: 'center', justifyContent: 'center',
+                      fontSize: '0.56rem', fontWeight: 700, color: CELL_TEXT,
+                      background: CELL_COLORS[l].headerFill,
+                    }}>
+                      {showLabel ? `${counts[l]} ${l}` : counts[l]}
+                    </div>
+                  );
+                })}
               </div>
             </div>
           );
@@ -1082,6 +1085,13 @@ export default function AssessmentSummaryPage() {
 
   useEffect(load, [courseId, assignmentId]);
 
+  useEffect(() => {
+    if (!drawerOpen) return;
+    const onKey = (e) => { if (e.key === 'Escape') setDrawerOpen(false); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [drawerOpen]);
+
   if (loading) return <div className="loading">Loading...</div>;
   if (error) return <div className="error-msg">{error}</div>;
   if (!data) return null;
@@ -1188,10 +1198,15 @@ export default function AssessmentSummaryPage() {
       {drawerOpen && (
         <>
           <div
+            aria-hidden="true"
             onClick={() => setDrawerOpen(false)}
             style={{ position: 'fixed', inset: 0, background: 'rgba(20,20,30,0.28)', zIndex: 40 }}
           />
-          <div style={{
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="reviewer-analysis-title"
+            style={{
             position: 'fixed', top: 0, right: 0, height: '100%', width: 360,
             background: 'var(--card-bg)', boxShadow: '-6px 0 20px rgba(0,0,0,0.16)',
             zIndex: 50, overflowY: 'auto',
@@ -1202,7 +1217,7 @@ export default function AssessmentSummaryPage() {
               background: 'var(--bg-subtle)', position: 'sticky', top: 0,
             }}>
               <span style={{ color: '#8b5cf6' }}>✦</span>
-              <span style={{ fontWeight: 700, fontSize: '0.84rem' }}>Reviewer Analysis</span>
+              <span id="reviewer-analysis-title" style={{ fontWeight: 700, fontSize: '0.84rem' }}>Reviewer Analysis</span>
               <span style={{
                 fontSize: '0.58rem', background: 'var(--bg-subtle)', color: 'var(--text-muted)',
                 borderRadius: 5, padding: '1px 5px', fontWeight: 600,

--- a/client/src/pages/AssessmentSummaryPage.jsx
+++ b/client/src/pages/AssessmentSummaryPage.jsx
@@ -587,7 +587,7 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
               {LEVELS.map(l => (
                 <th key={l} style={{
                   padding: '0.3rem 0.5rem', textAlign: 'center', width: '12%',
-                  background: LEVEL_COLORS[l].bg, color: LEVEL_COLORS[l].text,
+                  background: CELL_COLORS[l].headerFill, color: CELL_TEXT,
                   border: '1px solid var(--border)', fontWeight: 600, fontSize: '0.72rem',
                   whiteSpace: 'nowrap',
                 }}>

--- a/client/src/pages/AssessmentSummaryPage.jsx
+++ b/client/src/pages/AssessmentSummaryPage.jsx
@@ -620,7 +620,7 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
           <tbody>
             {topics.map(t => {
               const currentGrade = student.scores[t.id]?.grade || null;
-              const pendingGrade = pending[t.id] || null;
+              const pendingGrade = pending[t.id] ?? null;
               const suggestedLevel = null; // wired in Slice 4 (rubric suggestion overlay)
 
               return (

--- a/client/src/pages/AssessmentSummaryPage.jsx
+++ b/client/src/pages/AssessmentSummaryPage.jsx
@@ -20,6 +20,22 @@ const LEVEL_COLORS = {
   EM: { bg: '#ffedd5', text: '#9a3412', border: '#fed7aa', activeBg: '#ea580c', activeText: '#fff' },
   IE: { bg: '#fee2e2', text: '#991b1b', border: '#fca5a5', activeBg: '#dc2626', activeText: '#fff' },
 };
+// PrisMCP cell language (spec §1). Header tint = final fill; cell text is always
+// black because descriptor text will later replace the level codes, so colour
+// cannot carry meaning in the text. Kept inline (deliberate local exception to
+// the app.css CSS-var convention) — consistent with LEVEL_COLORS above.
+const CELL_COLORS = {
+  ED: { headerFill: '#bfdbfe', draftFill: '#eff6ff', finalBorder: '#2563eb', draftBorder: '#93c5fd' },
+  EX: { headerFill: '#bbf7d0', draftFill: '#f0fdf4', finalBorder: '#16a34a', draftBorder: '#86efac' },
+  D:  { headerFill: '#fef08a', draftFill: '#fefce8', finalBorder: '#ca8a04', draftBorder: '#fcd34d' },
+  EM: { headerFill: '#fed7aa', draftFill: '#fff7ed', finalBorder: '#ea580c', draftBorder: '#fdba74' },
+  IE: { headerFill: '#fecaca', draftFill: '#fef2f2', finalBorder: '#dc2626', draftBorder: '#fca5a5' },
+};
+// Suggestion accent — deliberately violet, NOT yellow (Developing is already yellow).
+const SUGGEST = { fill: '#ede9fe', ring: '#a78bfa', glyph: '#8b5cf6' };
+const CELL_TEXT = '#1a1a1a';
+// Sentinel stored in pending[topicId] to stage a synced final for removal (Slice 2).
+const REMOVE = '__remove__';
 
 function displayName(student) {
   return `${student.preferred_name_teacher || student.preferred_name || student.first_name} ${student.last_name}`;

--- a/client/src/pages/AssessmentSummaryPage.jsx
+++ b/client/src/pages/AssessmentSummaryPage.jsx
@@ -14,17 +14,10 @@ const LEVEL_LABELS = {
 };
 const LEVEL_POINTS = { ED: 100, EX: 75, D: 50, EM: 25, IE: 0 };
 const EXCEPTION_LABELS = { 1: 'Excused', 2: 'Incomplete', 3: 'Missing', 4: 'Late' };
-const LEVEL_COLORS = {
-  ED: { bg: '#dbeafe', text: '#1e40af', border: '#93c5fd', activeBg: '#1d4ed8', activeText: '#fff' },
-  EX: { bg: '#dcfce7', text: '#166534', border: '#86efac', activeBg: '#16a34a', activeText: '#fff' },
-  D:  { bg: '#fef9c3', text: '#713f12', border: '#fde047', activeBg: '#ca8a04', activeText: '#fff' },
-  EM: { bg: '#ffedd5', text: '#9a3412', border: '#fed7aa', activeBg: '#ea580c', activeText: '#fff' },
-  IE: { bg: '#fee2e2', text: '#991b1b', border: '#fca5a5', activeBg: '#dc2626', activeText: '#fff' },
-};
 // PrisMCP cell language (spec §1). Header tint = final fill; cell text is always
 // black because descriptor text will later replace the level codes, so colour
 // cannot carry meaning in the text. Kept inline (deliberate local exception to
-// the app.css CSS-var convention) — consistent with LEVEL_COLORS above.
+// the app.css CSS-var convention).
 const CELL_COLORS = {
   ED: { headerFill: '#bfdbfe', draftFill: '#eff6ff', finalBorder: '#2563eb', draftBorder: '#93c5fd' },
   EX: { headerFill: '#bbf7d0', draftFill: '#f0fdf4', finalBorder: '#16a34a', draftBorder: '#86efac' },
@@ -728,7 +721,7 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
                             {l}
                           </span>
                         ) : null}
-                        {isSuggested && (
+                        {isSuggested && !stagedRemoval && (
                           <span style={{
                             position: 'absolute', top: 1, right: 3, fontSize: '0.58rem',
                             lineHeight: 1, color: SUGGEST.glyph,

--- a/client/src/pages/AssessmentSummaryPage.jsx
+++ b/client/src/pages/AssessmentSummaryPage.jsx
@@ -855,8 +855,39 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
             </svg>
           </button>
 
-          {/* ↑ Use suggestion — added in Task 5.3 */}
+          {hasSuggestion && narrativeSuggestion && (
+            <button
+              className="btn-violet"
+              onClick={() => applyComment(normalizePastedText(narrativeSuggestion))}
+              title="Copy the suggestion up into your comment"
+              style={{
+                borderRadius: 7, padding: '0.4rem 0.75rem', fontSize: '0.74rem',
+                fontWeight: 600, cursor: 'pointer',
+                background: '#ede9fe', color: '#6d28d9', border: '1px solid #c4b5fd',
+              }}
+            >
+              ↑ Use suggestion
+            </button>
+          )}
         </div>
+
+        {narrativeSuggestion && (
+          <div style={{
+            marginTop: '0.55rem', border: '1px solid #e6e1f3', background: '#faf9fd',
+            borderRadius: 7, padding: '0.5rem 0.65rem',
+          }}>
+            <div style={{
+              fontSize: '0.63rem', fontWeight: 600, color: '#9a90b8',
+              letterSpacing: '0.03em', marginBottom: '0.28rem',
+              display: 'flex', alignItems: 'center', gap: '0.3rem',
+            }}>
+              ✦ Suggested feedback
+            </div>
+            <div style={{ fontSize: '0.72rem', lineHeight: 1.4, color: '#716b85', whiteSpace: 'pre-wrap' }}>
+              {narrativeSuggestion}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/client/src/pages/AssessmentSummaryPage.jsx
+++ b/client/src/pages/AssessmentSummaryPage.jsx
@@ -75,7 +75,6 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
 
   const reviewerFlags = feedbackRow?.feedback_parsed?.reviewer_flags || null;
   const narrativeSuggestion = feedbackRow?.feedback_parsed?.narrative_feedback || null;
-  const hasSuggestion = !!narrativeSuggestion || Object.keys(suggestedByTopic).length > 0;
 
   // Restore any unsaved draft for this card from localStorage (#47). Read once
   // on mount; a restored draft means the teacher already interacted with the
@@ -794,25 +793,19 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
           </button>
 
           {/* Display-to-student: eye icon + switch, no text label */}
-          <span
+          <button
+            type="button"
             role="switch"
             aria-checked={display}
             aria-label="Display to student"
             title="Display to student"
-            tabIndex={0}
             onClick={() => { setDisplay(d => !d); setAutoFlipArmed(false); }}
-            onKeyDown={e => {
-              if (e.key === ' ' || e.key === 'Enter') {
-                e.preventDefault();
-                setDisplay(d => !d);
-                setAutoFlipArmed(false);
-              }
-            }}
             style={{
               display: 'inline-flex', alignItems: 'center', gap: '0.35rem',
               border: '1px solid var(--border)', borderRadius: 7,
               padding: '0.18rem 0.4rem', background: 'var(--card-bg)',
               color: 'var(--text-muted)', cursor: 'pointer', userSelect: 'none',
+              font: 'inherit',
             }}
           >
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -829,7 +822,7 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
                 boxShadow: '0 1px 2px rgba(0,0,0,0.2)', transition: 'left 0.15s',
               }} />
             </span>
-          </span>
+          </button>
 
           {/* Discard — trash icon, always shown, disabled when nothing pending */}
           <button
@@ -855,9 +848,8 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
             </svg>
           </button>
 
-          {hasSuggestion && narrativeSuggestion && (
+          {narrativeSuggestion && (
             <button
-              className="btn-violet"
               onClick={() => applyComment(normalizePastedText(narrativeSuggestion))}
               title="Copy the suggestion up into your comment"
               style={{

--- a/client/src/pages/AssessmentSummaryPage.jsx
+++ b/client/src/pages/AssessmentSummaryPage.jsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { getMasteryForAssignment, syncMasteryForAssignment, writeMasteryScores, writeMasteryComment, sendAllGrades, createFlag, deleteFlag } from '../services/api.js';
+import { getMasteryForAssignment, getFeedbackForAssignment, getAssessmentAnalysis, syncMasteryForAssignment, writeMasteryScores, writeMasteryComment, sendAllGrades, createFlag, deleteFlag } from '../services/api.js';
 import { draftKey, readDraft, writeDraft, clearDraft, draftBaseline } from '../lib/assessmentDraft.js';
+import { resolveRubricScores } from '../lib/rubricSuggestions.js';
 
 const LEVELS = ['ED', 'EX', 'D', 'EM', 'IE'];
 const LEVEL_LABELS = {
@@ -61,12 +62,16 @@ function normalizePastedText(text) {
 
 // ── Per-student rubric card ──────────────────────────────────────────────────
 
-export function StudentRubricCard({ student, topics, courseId, assignmentId, assignmentRow, onSaved, onPendingChange, registerCard, unregisterCard }) {
+export function StudentRubricCard({ student, topics, courseId, assignmentId, assignmentRow, feedbackRow, onSaved, onPendingChange, registerCard, unregisterCard }) {
   const loadedDisplay = student.comment_status === 1;
   const storageKey = draftKey(courseId, assignmentId, student.enrollment_id);
   // Signature of the synced Schoology values this card was rendered against.
   // A stored draft is only valid while this is unchanged (#47).
   const currentBaseline = draftBaseline(student, topics);
+
+  // Reviewer rubric suggestions resolved to topic ids (spec §5). Best-effort:
+  // unresolved keys / out-of-set values are silently dropped by the resolver.
+  const suggestedByTopic = resolveRubricScores(feedbackRow?.feedback_parsed?.rubric_scores, topics);
 
   // Restore any unsaved draft for this card from localStorage (#47). Read once
   // on mount; a restored draft means the teacher already interacted with the
@@ -621,7 +626,7 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
             {topics.map(t => {
               const currentGrade = student.scores[t.id]?.grade || null;
               const pendingGrade = pending[t.id] ?? null;
-              const suggestedLevel = null; // wired in Slice 4 (rubric suggestion overlay)
+              const suggestedLevel = suggestedByTopic[t.id] || null;
 
               return (
                 <tr key={t.id}>
@@ -827,6 +832,8 @@ export default function AssessmentSummaryPage() {
   const [error, setError] = useState(null);
   const [refreshing, setRefreshing] = useState(false);
   const [refreshResult, setRefreshResult] = useState(null);
+  const [feedbackByStudent, setFeedbackByStudent] = useState({});
+  const [analysis, setAnalysis] = useState(null);
 
   // "Send all" bar state (#51). pendingByUid maps each card's uid → true while
   // it has unsaved changes; cardsRef holds each card's { getEntry, applyResult }
@@ -906,8 +913,16 @@ export default function AssessmentSummaryPage() {
 
   function load() {
     setLoading(true);
-    getMasteryForAssignment(courseId, assignmentId)
-      .then(setData)
+    Promise.all([
+      getMasteryForAssignment(courseId, assignmentId),
+      getFeedbackForAssignment(assignmentId).catch(() => ({})),
+      getAssessmentAnalysis(assignmentId).catch(() => null),
+    ])
+      .then(([mastery, feedback, analysisRow]) => {
+        setData(mastery);
+        setFeedbackByStudent(feedback || {});
+        setAnalysis(analysisRow || null);
+      })
       .catch(e => setError(e.message))
       .finally(() => setLoading(false));
   }
@@ -989,6 +1004,7 @@ export default function AssessmentSummaryPage() {
               courseId={courseId}
               assignmentId={assignmentId}
               assignmentRow={assignment}
+              feedbackRow={feedbackByStudent[student.id] || null}
               onSaved={handleCardSaved}
               onPendingChange={handlePendingChange}
               registerCard={registerCard}

--- a/client/src/pages/AssessmentSummaryPage.jsx
+++ b/client/src/pages/AssessmentSummaryPage.jsx
@@ -751,9 +751,9 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
         </table>
       </div>
 
-      {/* Comment + update */}
+      {/* Overall Comment — the hero */}
       <div style={{ padding: '0.75rem 1rem' }}>
-        <label style={{ display: 'block', fontSize: '0.78rem', fontWeight: 600, marginBottom: '0.3rem', color: 'var(--text-muted)' }}>
+        <label style={{ display: 'block', fontSize: '0.7rem', fontWeight: 700, margin: '0 0 0.35rem', color: '#333' }}>
           Overall Comment
         </label>
         <textarea
@@ -773,71 +773,89 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
               el.setSelectionRange(pos, pos);
             });
           }}
-          rows={3}
-          style={{ width: '100%', fontSize: '0.82rem', resize: 'vertical', boxSizing: 'border-box' }}
+          rows={4}
+          style={{
+            width: '100%', boxSizing: 'border-box', border: '1.5px solid var(--border)',
+            borderRadius: 8, padding: '0.6rem', fontSize: '0.84rem', lineHeight: 1.45,
+            fontFamily: 'inherit', resize: 'vertical', color: 'var(--text)',
+          }}
           placeholder="Teacher comment for this student on this assessment..."
         />
-        <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.4rem', alignItems: 'center' }}>
+
+        {/* Control band — directly under the comment (creates the focus boundary) */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '0.6rem' }}>
           <button
             className="primary"
             onClick={handleSave}
             disabled={saving || !hasPendingChanges}
+            title="Write scores & comment back to Schoology"
           >
             {saving ? 'Saving...' : 'Update Schoology'}
           </button>
-          {hasPendingChanges && !saving && (
-            <button className="ghost" onClick={() => {
+
+          {/* Display-to-student: eye icon + switch, no text label */}
+          <span
+            role="switch"
+            aria-checked={display}
+            aria-label="Display to student"
+            title="Display to student"
+            tabIndex={0}
+            onClick={() => { setDisplay(d => !d); setAutoFlipArmed(false); }}
+            onKeyDown={e => {
+              if (e.key === ' ' || e.key === 'Enter') {
+                e.preventDefault();
+                setDisplay(d => !d);
+                setAutoFlipArmed(false);
+              }
+            }}
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: '0.35rem',
+              border: '1px solid var(--border)', borderRadius: 7,
+              padding: '0.18rem 0.4rem', background: 'var(--card-bg)',
+              color: 'var(--text-muted)', cursor: 'pointer', userSelect: 'none',
+            }}
+          >
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z" /><circle cx="12" cy="12" r="3" />
+            </svg>
+            <span style={{
+              position: 'relative', width: 28, height: 16, borderRadius: 9,
+              background: display ? 'var(--accent)' : 'var(--bg-subtle)',
+              border: '1px solid var(--border)', transition: 'background 0.15s',
+            }}>
+              <span style={{
+                position: 'absolute', top: 1, left: display ? 13 : 1,
+                width: 12, height: 12, borderRadius: '50%', background: '#fff',
+                boxShadow: '0 1px 2px rgba(0,0,0,0.2)', transition: 'left 0.15s',
+              }} />
+            </span>
+          </span>
+
+          {/* Discard — trash icon, always shown, disabled when nothing pending */}
+          <button
+            onClick={() => {
               setPending({});
               setComment(student.grade_comment || '');
               setDisplay(loadedDisplay);
               setAutoFlipArmed(student.comment_status !== 1 && !student.grade_comment);
-            }}>
-              Discard Changes
-            </button>
-          )}
-          {!hasPendingChanges && (
-            <span className="text-sm text-muted">No changes</span>
-          )}
-          <label
-            style={{
-              marginLeft: 'auto', display: 'inline-flex', alignItems: 'center',
-              gap: '0.5rem', fontSize: '0.78rem', color: 'var(--text-muted)',
-              cursor: 'pointer', userSelect: 'none',
             }}
-            title="When ON, the student sees this assignment's grade, comment, and proficiencies on Schoology."
+            disabled={!hasPendingChanges}
+            aria-label="Discard changes"
+            title={hasPendingChanges ? 'Discard changes' : 'Discard changes (nothing to discard)'}
+            style={{
+              display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+              width: 30, height: 28, borderRadius: 7,
+              border: '1px solid var(--border)', background: 'var(--card-bg)',
+              color: hasPendingChanges ? 'var(--text-muted)' : 'var(--border)',
+              cursor: hasPendingChanges ? 'pointer' : 'default',
+            }}
           >
-            Display to student
-            <span
-              role="switch"
-              aria-checked={display}
-              aria-label="Display to student"
-              tabIndex={0}
-              onClick={() => {
-                setDisplay(d => !d);
-                setAutoFlipArmed(false);
-              }}
-              onKeyDown={e => {
-                if (e.key === ' ' || e.key === 'Enter') {
-                  e.preventDefault();
-                  setDisplay(d => !d);
-                  setAutoFlipArmed(false);
-                }
-              }}
-              style={{
-                position: 'relative', width: 36, height: 20,
-                background: display ? 'var(--accent)' : 'var(--bg-subtle)',
-                border: '1px solid var(--border)', borderRadius: 999,
-                transition: 'background 0.15s',
-              }}
-            >
-              <span style={{
-                position: 'absolute', top: 1, left: display ? 17 : 1,
-                width: 16, height: 16, borderRadius: '50%',
-                background: '#fff', boxShadow: '0 1px 2px rgba(0,0,0,0.2)',
-                transition: 'left 0.15s',
-              }} />
-            </span>
-          </label>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14" />
+            </svg>
+          </button>
+
+          {/* ↑ Use suggestion — added in Task 5.3 */}
         </div>
       </div>
     </div>

--- a/client/src/pages/AssessmentSummaryPage.jsx
+++ b/client/src/pages/AssessmentSummaryPage.jsx
@@ -686,9 +686,7 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
                     if (isSuggested) {
                       cellStyle = {
                         ...cellStyle,
-                        ...(stagedRemoval
-                          ? { outline: cellStyle.outline, outlineOffset: cellStyle.outlineOffset }
-                          : { outline: `1px dashed ${SUGGEST.ring}`, outlineOffset: '-3px' }),
+                        ...(stagedRemoval ? {} : { outline: `1px dashed ${SUGGEST.ring}`, outlineOffset: '-3px' }),
                         zIndex: 2,
                         ...(hasTeacherMark ? {} : { background: SUGGEST.fill }),
                       };

--- a/client/src/pages/AssessmentSummaryPage.jsx
+++ b/client/src/pages/AssessmentSummaryPage.jsx
@@ -73,6 +73,10 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
   // unresolved keys / out-of-set values are silently dropped by the resolver.
   const suggestedByTopic = resolveRubricScores(feedbackRow?.feedback_parsed?.rubric_scores, topics);
 
+  const reviewerFlags = feedbackRow?.feedback_parsed?.reviewer_flags || null;
+  const narrativeSuggestion = feedbackRow?.feedback_parsed?.narrative_feedback || null;
+  const hasSuggestion = !!narrativeSuggestion || Object.keys(suggestedByTopic).length > 0;
+
   // Restore any unsaved draft for this card from localStorage (#47). Read once
   // on mount; a restored draft means the teacher already interacted with the
   // card, so auto-flip starts disarmed. A draft whose `base` no longer matches
@@ -592,6 +596,25 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
           </span>
         )}
       </div>
+
+      {/* Reviewer flags strip — collapsed by default */}
+      {reviewerFlags && (
+        <details style={{
+          border: '1px solid #e6c98a', background: '#fffbef', borderRadius: 7,
+          margin: '0.75rem 1rem 0',
+        }}>
+          <summary style={{
+            cursor: 'pointer', listStyle: 'none', padding: '0.45rem 0.7rem',
+            fontSize: '0.72rem', fontWeight: 600, color: '#92740f',
+            display: 'flex', alignItems: 'center', gap: '0.45rem',
+          }}>
+            ⚑ Reviewer flags
+          </summary>
+          <div style={{ padding: '0 0.7rem 0.6rem', fontSize: '0.72rem', lineHeight: 1.5, color: '#5a4a1f' }}>
+            {reviewerFlags}
+          </div>
+        </details>
+      )}
 
       {/* Rubric grid */}
       <div style={{

--- a/client/src/pages/AssessmentSummaryPage.jsx
+++ b/client/src/pages/AssessmentSummaryPage.jsx
@@ -189,17 +189,34 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
   function selectLevel(topicId, level) {
     if (isRubricLocked) return;
     const currentGrade = student.scores[topicId]?.grade;
-    if (level === currentGrade) {
-      // Clicking current — deselect pending
+    const pendingVal = pending[topicId];
+
+    // Re-clicking a drafted cell toggles it off (back to whatever is synced).
+    if (pendingVal != null && pendingVal !== REMOVE && level === pendingVal) {
       setPending(p => { const n = { ...p }; delete n[topicId]; return n; });
-    } else {
-      // Auto-flip ON the first time a real selection is made for a virgin
-      // record. Deselect clicks (level === currentGrade) don't count.
-      if (autoFlipArmed) {
-        setDisplay(true);
-        setAutoFlipArmed(false);
-      }
-      setPending(p => ({ ...p, [topicId]: level }));
+      return;
+    }
+    // Re-clicking the staged final cell unstages the removal.
+    if (pendingVal === REMOVE && level === currentGrade) {
+      setPending(p => { const n = { ...p }; delete n[topicId]; return n; });
+      return;
+    }
+    // Clicking the synced final with nothing pending stages it for removal.
+    if (pendingVal == null && level === currentGrade) {
+      armAutoFlip();
+      setPending(p => ({ ...p, [topicId]: REMOVE }));
+      return;
+    }
+    // Otherwise set/replace a draft on this level.
+    armAutoFlip();
+    setPending(p => ({ ...p, [topicId]: level }));
+  }
+
+  // Auto-flip the display toggle ON the first real selection for a virgin record.
+  function armAutoFlip() {
+    if (autoFlipArmed) {
+      setDisplay(true);
+      setAutoFlipArmed(false);
     }
   }
 

--- a/client/src/pages/AssessmentSummaryPage.jsx
+++ b/client/src/pages/AssessmentSummaryPage.jsx
@@ -1015,7 +1015,11 @@ export default function AssessmentSummaryPage() {
 
   return (
     <div className="fade-in">
-      <div style={{ marginBottom: '1.25rem' }}>
+      <div style={{
+        position: 'sticky', top: 0, zIndex: 5, background: 'var(--bg)',
+        marginBottom: '1.25rem', padding: '0.55rem 0',
+        borderBottom: '1px solid var(--border)',
+      }}>
         <Link to={`/course/${courseId}`} className="link" style={{ fontSize: '0.85rem', color: 'var(--text-muted)' }}>
           ← Back to course
         </Link>
@@ -1033,23 +1037,6 @@ export default function AssessmentSummaryPage() {
             <span className="text-sm text-muted" style={{ fontSize: '0.75rem' }}>{refreshResult}</span>
           )}
         </div>
-      </div>
-
-      {/* Proficiency level legend */}
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem', flexWrap: 'wrap' }}>
-        {LEVELS.map(l => (
-          <span key={l} style={{
-            display: 'inline-flex', alignItems: 'center', gap: '0.3rem',
-            padding: '0.2rem 0.5rem', borderRadius: 6,
-            background: LEVEL_COLORS[l].bg, color: LEVEL_COLORS[l].text,
-            fontSize: '0.72rem', fontWeight: 600, border: `1px solid ${LEVEL_COLORS[l].border}`,
-          }}>
-            {l} — {LEVEL_LABELS[l]}
-          </span>
-        ))}
-        <span style={{ marginLeft: 'auto', fontSize: '0.72rem', color: 'var(--text-muted)', alignSelf: 'center' }}>
-          Click a cell to change proficiency · green border = pending · solid green = current
-        </span>
       </div>
 
       {students.length === 0 ? (

--- a/client/src/pages/AssessmentSummaryPage.jsx
+++ b/client/src/pages/AssessmentSummaryPage.jsx
@@ -225,11 +225,14 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
   // gradeInfo from every aligned topic, with pending changes merged over the
   // current scores. Numeric grade strings ("100"/"75"/...) only: the DB stores
   // letter codes, but Schoology silently drops them — always map via LEVEL_POINTS.
+  // `t.id in pending` distinguishes a cleared draft (key deleted → fall back to
+  // synced) from a staged removal (REMOVE → omit so the /observations replace
+  // clears it in Schoology).
   function buildGradeInfo() {
     const gradeInfo = {};
     for (const t of topics) {
-      const level = pending[t.id] ?? student.scores[t.id]?.grade;
-      if (level == null) continue;
+      const level = (t.id in pending) ? pending[t.id] : student.scores[t.id]?.grade;
+      if (level == null || level === REMOVE) continue;
       const points = LEVEL_POINTS[level];
       if (points == null) continue;
       gradeInfo[t.id] = { grade: String(points), gradingScaleId: 21337256 };
@@ -242,8 +245,8 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
   function buildSavedScores() {
     const newScores = {};
     for (const t of topics) {
-      const level = pending[t.id] ?? student.scores[t.id]?.grade;
-      if (level == null) continue;
+      const level = (t.id in pending) ? pending[t.id] : student.scores[t.id]?.grade;
+      if (level == null || level === REMOVE) continue;
       newScores[t.id] = { points: LEVEL_POINTS[level], grade: level };
     }
     return newScores;

--- a/client/src/pages/AssessmentSummaryPage.jsx
+++ b/client/src/pages/AssessmentSummaryPage.jsx
@@ -601,6 +601,7 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
             {topics.map(t => {
               const currentGrade = student.scores[t.id]?.grade || null;
               const pendingGrade = pending[t.id] || null;
+              const suggestedLevel = null; // wired in Slice 4 (rubric suggestion overlay)
 
               return (
                 <tr key={t.id}>
@@ -612,9 +613,16 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
                     <div style={{ fontSize: '0.65rem', color: 'var(--text-muted)', opacity: 0.7 }}>{t.category_title} · {t.external_id}</div>
                   </td>
                   {LEVELS.map(l => {
-                    const isCurrent = l === currentGrade;
-                    const isPending = l === pendingGrade;
-                    const c = LEVEL_COLORS[l];
+                    const c = CELL_COLORS[l];
+                    const pendingVal = pendingGrade;                 // pending[t.id] || null (from outer scope)
+                    const stagedRemoval = pendingVal === REMOVE && l === currentGrade;
+                    const isDraft = pendingVal !== REMOVE && l === pendingVal;
+                    // A synced final shows ONLY when nothing is pending for this topic (a pending
+                    // draft on another cell overrides it → that old final renders Empty; spec §2).
+                    const isFinal = l === currentGrade && pendingVal == null;
+                    // Suggestion overlay inputs arrive in Slice 4; null-safe until then.
+                    const isSuggested = suggestedLevel != null && l === suggestedLevel;
+                    const hasTeacherMark = isFinal || isDraft || stagedRemoval;
 
                     let cellStyle = {
                       padding: '0.25rem 0.4rem',
@@ -623,20 +631,44 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
                       cursor: 'pointer',
                       userSelect: 'none',
                       transition: 'all 0.1s',
+                      color: CELL_TEXT,
+                      background: 'var(--card-bg)',
                     };
 
-                    if (isCurrent && !pendingGrade) {
-                      // Currently awarded, no pending change → solid green fill
-                      cellStyle = { ...cellStyle, background: '#16a34a', border: '2px solid #15803d' };
-                    } else if (isPending) {
-                      // Pending selection → green border, light fill
-                      cellStyle = { ...cellStyle, background: c.bg, border: `2px solid #16a34a` };
-                    } else if (isCurrent && pendingGrade) {
-                      // Was current but overridden by a pending change → show dimmed
-                      cellStyle = { ...cellStyle, background: c.bg, opacity: 0.4 };
-                    } else {
-                      cellStyle = { ...cellStyle, background: 'var(--card-bg)' };
+                    if (isFinal) {
+                      cellStyle = {
+                        ...cellStyle, background: c.headerFill,
+                        border: `2px solid ${c.finalBorder}`, fontWeight: 700,
+                        position: 'relative', zIndex: 2,
+                      };
+                    } else if (isDraft) {
+                      cellStyle = {
+                        ...cellStyle, background: c.draftFill,
+                        border: `2px solid ${c.draftBorder}`,
+                        position: 'relative', zIndex: 2,
+                      };
+                    } else if (stagedRemoval) {
+                      // Removal marker (Slice 2): default bg, red dashed ring + ✕ glyph.
+                      cellStyle = {
+                        ...cellStyle, background: 'var(--card-bg)',
+                        outline: '1.5px dashed #ef4444', outlineOffset: '-3px',
+                        position: 'relative', zIndex: 2,
+                      };
                     }
+
+                    // Suggestion overlay (Slice 4) composes on top: dashed violet ring always;
+                    // violet wash only when there is no teacher mark in this cell (spec §2).
+                    if (isSuggested) {
+                      cellStyle = {
+                        ...cellStyle,
+                        outline: stagedRemoval ? cellStyle.outline : `1px dashed ${SUGGEST.ring}`,
+                        outlineOffset: '-3px',
+                        position: 'relative', zIndex: 2,
+                        ...(hasTeacherMark ? {} : { background: SUGGEST.fill }),
+                      };
+                    }
+
+                    const showCode = isFinal || isDraft || stagedRemoval || isSuggested;
 
                     return (
                       <td
@@ -645,14 +677,23 @@ export function StudentRubricCard({ student, topics, courseId, assignmentId, ass
                         onClick={() => selectLevel(t.id, l)}
                         title={`Set ${t.title} to ${LEVEL_LABELS[l]}`}
                       >
-                        {(isCurrent || isPending) ? (
-                          <span style={{
-                            fontWeight: 700, fontSize: '0.75rem',
-                            color: isCurrent && !pendingGrade ? '#fff' : isPending ? '#16a34a' : c.text,
-                          }}>
+                        {showCode ? (
+                          <span style={{ fontWeight: isFinal ? 700 : 400, fontSize: '0.75rem', color: CELL_TEXT }}>
                             {l}
                           </span>
                         ) : null}
+                        {isSuggested && (
+                          <span style={{
+                            position: 'absolute', top: 1, right: 3, fontSize: '0.58rem',
+                            lineHeight: 1, color: SUGGEST.glyph,
+                          }}>✦</span>
+                        )}
+                        {stagedRemoval && (
+                          <span style={{
+                            position: 'absolute', top: 0, right: 2, fontSize: '0.6rem',
+                            lineHeight: 1, color: '#ef4444',
+                          }}>✕</span>
+                        )}
                       </td>
                     );
                   })}

--- a/client/src/pages/AssessmentSummaryPage.test.jsx
+++ b/client/src/pages/AssessmentSummaryPage.test.jsx
@@ -219,6 +219,8 @@ describe('StudentRubricCard — cell language (Slice 1)', () => {
     renderCard();
     const edHeader = screen.getByText('Exhibiting Depth').closest('th');
     expect(edHeader).toHaveStyle({ background: '#bfdbfe', color: '#1a1a1a' });
+    const ieHeader = screen.getByText('Insufficient Evidence').closest('th');
+    expect(ieHeader).toHaveStyle({ background: '#fecaca', color: '#1a1a1a' });
   });
 
   it('renders a synced final cell with its final fill, 2px final border, bold, black text', () => {

--- a/client/src/pages/AssessmentSummaryPage.test.jsx
+++ b/client/src/pages/AssessmentSummaryPage.test.jsx
@@ -596,6 +596,34 @@ describe('StudentRubricCard — card chrome (Slice 5)', () => {
     renderCard(withFeedback({ narrative_feedback: 'x' }));
     expect(screen.queryByText(/Reviewer flags/)).not.toBeInTheDocument();
   });
+
+  it('makes the comment the hero with a bold label and a larger textarea', () => {
+    renderCard();
+    const ta = screen.getByPlaceholderText(/Teacher comment/i);
+    expect(ta).toHaveStyle({ fontSize: '0.84rem' });
+  });
+
+  it('shows the display toggle as an eye-icon switch with no text label', () => {
+    renderCard();
+    const toggle = screen.getByRole('switch', { name: /display to student/i });
+    expect(toggle).toBeInTheDocument();
+    expect(screen.queryByText('Display to student')).not.toBeInTheDocument();
+  });
+
+  it('always shows the discard control, disabled when there are no pending changes', () => {
+    renderCard();
+    const discard = screen.getByRole('button', { name: /discard changes/i });
+    expect(discard).toBeDisabled();
+  });
+
+  it('enables discard once there is a pending change and clears it on click', () => {
+    renderCard();
+    fireEvent.click(screen.getByTitle('Set Topic 1 to Developing'));
+    const discard = screen.getByRole('button', { name: /discard changes/i });
+    expect(discard).toBeEnabled();
+    fireEvent.click(discard);
+    expect(screen.queryByText(/pending change/)).not.toBeInTheDocument();
+  });
 });
 
 describe('AssessmentSummaryPage — feedback load (Slice 4)', () => {

--- a/client/src/pages/AssessmentSummaryPage.test.jsx
+++ b/client/src/pages/AssessmentSummaryPage.test.jsx
@@ -617,6 +617,7 @@ describe('AssessmentSummaryPage — feedback load (Slice 4)', () => {
   });
 
   it('does not throw or overlay for an unresolvable rubric_scores key', async () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
     getMasteryForAssignment.mockResolvedValue(makeData());
     getFeedbackForAssignment.mockResolvedValue({
       1: { feedback_parsed: { rubric_scores: { NOPE: 'ED' } } },
@@ -624,6 +625,7 @@ describe('AssessmentSummaryPage — feedback load (Slice 4)', () => {
     renderPage();
     await screen.findByTitle('Set Topic 1 to Exhibiting Depth');
     expect(screen.queryByText('✦')).not.toBeInTheDocument();
+    debugSpy.mockRestore();
   });
 
   it('keeps the solid final border + dashed ring + ✦ when teacher mark and suggestion agree', async () => {

--- a/client/src/pages/AssessmentSummaryPage.test.jsx
+++ b/client/src/pages/AssessmentSummaryPage.test.jsx
@@ -624,6 +624,29 @@ describe('StudentRubricCard — card chrome (Slice 5)', () => {
     fireEvent.click(discard);
     expect(screen.queryByText(/pending change/)).not.toBeInTheDocument();
   });
+
+  const withFeedback2 = (parsed) => ({ feedbackRow: { feedback_parsed: parsed } });
+
+  it('shows the suggested-feedback box and Use suggestion only when a suggestion exists', () => {
+    renderCard(); // no feedbackRow
+    expect(screen.queryByText('✦ Suggested feedback')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /use suggestion/i })).not.toBeInTheDocument();
+  });
+
+  it('renders the suggestion box (read-only) and Use suggestion when narrative_feedback exists', () => {
+    renderCard(withFeedback2({ narrative_feedback: 'Excellent work, Ada!' }));
+    expect(screen.getByText('✦ Suggested feedback')).toBeInTheDocument();
+    expect(screen.getByText('Excellent work, Ada!')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /use suggestion/i })).toBeInTheDocument();
+  });
+
+  it('Use suggestion overwrites the comment with normalized text and arms pending changes', () => {
+    renderCard(withFeedback2({ narrative_feedback: 'Line one.\v\v​Line two.' }));
+    fireEvent.click(screen.getByRole('button', { name: /use suggestion/i }));
+    const ta = screen.getByPlaceholderText(/Teacher comment/i);
+    expect(ta).toHaveValue('Line one.\n\nLine two.'); // normalizePastedText applied
+    expect(screen.getByRole('button', { name: 'Update Schoology' })).toBeEnabled();
+  });
 });
 
 describe('AssessmentSummaryPage — feedback load (Slice 4)', () => {

--- a/client/src/pages/AssessmentSummaryPage.test.jsx
+++ b/client/src/pages/AssessmentSummaryPage.test.jsx
@@ -491,6 +491,16 @@ describe('StudentRubricCard — rubric interaction (Slice 2)', () => {
     await waitFor(() => expect(onSaved).toHaveBeenCalled());
     expect(onSaved.mock.calls[0][1].scores.t1).toBeUndefined();
   });
+
+  it('replaces a staged removal with a draft when a different cell is clicked', () => {
+    const s = { ...makeStudent(), scores: { t1: { grade: 'ED', points: 100 } } };
+    renderCard({ student: s });
+    fireEvent.click(screen.getByTitle('Set Topic 1 to Exhibiting Depth')); // stage REMOVE on ED
+    fireEvent.click(screen.getByTitle('Set Topic 1 to Developing'));        // new draft on D
+    expect(screen.getByText('1 pending change')).toBeInTheDocument();
+    const draftCell = screen.getByTitle('Set Topic 1 to Developing');
+    expect(draftCell).toHaveStyle({ background: '#fefce8' }); // D draftFill
+  });
 });
 
 describe('AssessmentSummaryPage — Send all bar (#51)', () => {

--- a/client/src/pages/AssessmentSummaryPage.test.jsx
+++ b/client/src/pages/AssessmentSummaryPage.test.jsx
@@ -647,6 +647,12 @@ describe('StudentRubricCard — card chrome (Slice 5)', () => {
     expect(ta).toHaveValue('Line one.\n\nLine two.'); // normalizePastedText applied
     expect(screen.getByRole('button', { name: 'Update Schoology' })).toBeEnabled();
   });
+
+  it('hides Use suggestion and the box when only rubric_scores exist (no narrative)', () => {
+    renderCard({ feedbackRow: { feedback_parsed: { rubric_scores: { X1: 'ED' } } } });
+    expect(screen.queryByRole('button', { name: /use suggestion/i })).not.toBeInTheDocument();
+    expect(screen.queryByText('✦ Suggested feedback')).not.toBeInTheDocument();
+  });
 });
 
 describe('AssessmentSummaryPage — feedback load (Slice 4)', () => {

--- a/client/src/pages/AssessmentSummaryPage.test.jsx
+++ b/client/src/pages/AssessmentSummaryPage.test.jsx
@@ -580,6 +580,24 @@ describe('AssessmentSummaryPage — Send all bar (#51)', () => {
   });
 });
 
+describe('StudentRubricCard — card chrome (Slice 5)', () => {
+  const withFeedback = (parsed) => ({ feedbackRow: { feedback_parsed: parsed } });
+
+  it('renders the reviewer-flags strip, collapsed by default, when reviewer_flags is present', () => {
+    renderCard(withFeedback({ reviewer_flags: 'No prototype link pasted.' }));
+    const summary = screen.getByText(/Reviewer flags/);
+    expect(summary).toBeInTheDocument();
+    const details = summary.closest('details');
+    expect(details).not.toHaveAttribute('open'); // collapsed by default
+    expect(details).toHaveTextContent('No prototype link pasted.');
+  });
+
+  it('does not render the flags strip when reviewer_flags is absent', () => {
+    renderCard(withFeedback({ narrative_feedback: 'x' }));
+    expect(screen.queryByText(/Reviewer flags/)).not.toBeInTheDocument();
+  });
+});
+
 describe('AssessmentSummaryPage — feedback load (Slice 4)', () => {
   function makeData() {
     return {

--- a/client/src/pages/AssessmentSummaryPage.test.jsx
+++ b/client/src/pages/AssessmentSummaryPage.test.jsx
@@ -734,9 +734,23 @@ describe('AssessmentSummaryPage — header + Reviewer Analysis (Slice 6)', () =>
 
     expect(screen.getByText(/From the reviewer's suggested grades/)).toBeInTheDocument();
     expect(screen.getByText(/1 ED/)).toBeInTheDocument();
+    expect(screen.getByText(/1 EX/)).toBeInTheDocument();
     expect(screen.getByText('AI tool use')).toBeInTheDocument();
     expect(screen.getByText('Half the class used AI.')).toBeInTheDocument();
     expect(screen.getByText(/Worth a spot-check/)).toBeInTheDocument();
+  });
+
+  it('closes the drawer when the overlay scrim is clicked', async () => {
+    getMasteryForAssignment.mockResolvedValue(makeData());
+    getFeedbackForAssignment.mockResolvedValue({ 1: { feedback_parsed: { rubric_scores: { X1: 'ED' } } } });
+    getAssessmentAnalysis.mockResolvedValue({ analysis_parsed: { noticings: [] } });
+    const { container } = renderPage();
+    fireEvent.click(await screen.findByRole('button', { name: /reviewer analysis/i }));
+    expect(screen.getByText('not student-facing')).toBeInTheDocument();
+    // The scrim is the fixed full-screen overlay with aria-hidden.
+    const scrim = container.querySelector('[aria-hidden="true"]');
+    fireEvent.click(scrim);
+    await waitFor(() => expect(screen.queryByText('not student-facing')).not.toBeInTheDocument());
   });
 });
 

--- a/client/src/pages/AssessmentSummaryPage.test.jsx
+++ b/client/src/pages/AssessmentSummaryPage.test.jsx
@@ -3,10 +3,12 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { useState } from 'react';
 import AssessmentSummaryPage, { StudentRubricCard } from './AssessmentSummaryPage.jsx';
-import { createFlag, deleteFlag, writeMasteryScores, writeMasteryComment, sendAllGrades, getMasteryForAssignment } from '../services/api.js';
+import { createFlag, deleteFlag, writeMasteryScores, writeMasteryComment, sendAllGrades, getMasteryForAssignment, getFeedbackForAssignment, getAssessmentAnalysis } from '../services/api.js';
 
 vi.mock('../services/api.js', () => ({
   getMasteryForAssignment: vi.fn(),
+  getFeedbackForAssignment: vi.fn().mockResolvedValue({}),
+  getAssessmentAnalysis: vi.fn().mockResolvedValue(null),
   syncMasteryForAssignment: vi.fn(),
   writeMasteryScores: vi.fn().mockResolvedValue({}),
   writeMasteryComment: vi.fn().mockResolvedValue({}),
@@ -575,5 +577,84 @@ describe('AssessmentSummaryPage — Send all bar (#51)', () => {
     expect(await screen.findByText(/Sent 2 grades/)).toBeInTheDocument();
     // Both cards show their per-card saved badge after the batch.
     await waitFor(() => expect(screen.getAllByText('Saved ✓')).toHaveLength(2));
+  });
+});
+
+describe('AssessmentSummaryPage — feedback load (Slice 4)', () => {
+  function makeData() {
+    return {
+      assignment: { id: 50, schoology_assignment_id: '8', title: 'Quiz', mastery_grading_period_id: 1, mastery_grading_category_id: 2 },
+      topics: [{ id: 't1', title: 'Topic 1', category_title: 'Cat', external_id: 'X1' }],
+      students: [{ ...makeStudent(), id: 1, schoology_uid: 'uid-1', enrollment_id: 'enr-1', scores: {} }],
+    };
+  }
+  function renderPage() {
+    return render(
+      <MemoryRouter initialEntries={['/course/4/assessment/8']}>
+        <Routes>
+          <Route path="/course/:id/assessment/:assignmentId" element={<AssessmentSummaryPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+  }
+
+  it('fetches feedback + analysis for the assignment alongside mastery', async () => {
+    getMasteryForAssignment.mockResolvedValue(makeData());
+    renderPage();
+    await waitFor(() => expect(getFeedbackForAssignment).toHaveBeenCalledWith('8'));
+    expect(getAssessmentAnalysis).toHaveBeenCalledWith('8');
+  });
+
+  it('renders a suggestion overlay (✦) for a resolvable rubric_scores entry', async () => {
+    getMasteryForAssignment.mockResolvedValue(makeData());
+    getFeedbackForAssignment.mockResolvedValue({
+      1: { feedback_parsed: { rubric_scores: { X1: 'ED' }, narrative_feedback: 'nice' } },
+    });
+    renderPage();
+    const cell = await screen.findByTitle('Set Topic 1 to Exhibiting Depth'); // ED
+    await waitFor(() => expect(cell).toHaveTextContent('✦'));
+    expect(cell).toHaveStyle({ background: '#ede9fe' }); // violet wash, no teacher mark
+  });
+
+  it('does not throw or overlay for an unresolvable rubric_scores key', async () => {
+    getMasteryForAssignment.mockResolvedValue(makeData());
+    getFeedbackForAssignment.mockResolvedValue({
+      1: { feedback_parsed: { rubric_scores: { NOPE: 'ED' } } },
+    });
+    renderPage();
+    await screen.findByTitle('Set Topic 1 to Exhibiting Depth');
+    expect(screen.queryByText('✦')).not.toBeInTheDocument();
+  });
+
+  it('keeps the solid final border + dashed ring + ✦ when teacher mark and suggestion agree', async () => {
+    const data = makeData();
+    data.students[0].scores = { t1: { grade: 'ED', points: 100 } }; // teacher final on ED
+    getMasteryForAssignment.mockResolvedValue(data);
+    getFeedbackForAssignment.mockResolvedValue({
+      1: { feedback_parsed: { rubric_scores: { X1: 'ED' } } }, // suggestion also ED
+    });
+    renderPage();
+    const cell = await screen.findByTitle('Set Topic 1 to Exhibiting Depth');
+    await waitFor(() => expect(cell).toHaveTextContent('✦'));
+    expect(cell).toHaveStyle({
+      background: '#bfdbfe', border: '2px solid #2563eb',
+      outline: '1px dashed #a78bfa',
+    });
+  });
+
+  it('places teacher mark and suggestion on different cells side by side', async () => {
+    const data = makeData();
+    data.students[0].scores = { t1: { grade: 'ED', points: 100 } }; // final ED
+    getMasteryForAssignment.mockResolvedValue(data);
+    getFeedbackForAssignment.mockResolvedValue({
+      1: { feedback_parsed: { rubric_scores: { X1: 'EX' } } }, // suggestion EX
+    });
+    renderPage();
+    const finalCell = await screen.findByTitle('Set Topic 1 to Exhibiting Depth'); // ED
+    const suggCell = screen.getByTitle('Set Topic 1 to Exhibiting');             // EX
+    expect(finalCell).toHaveStyle({ background: '#bfdbfe' });   // final, no ✦
+    expect(finalCell).not.toHaveTextContent('✦');
+    expect(suggCell).toHaveStyle({ background: '#ede9fe' });    // violet wash + ✦
+    expect(suggCell).toHaveTextContent('✦');
   });
 });

--- a/client/src/pages/AssessmentSummaryPage.test.jsx
+++ b/client/src/pages/AssessmentSummaryPage.test.jsx
@@ -220,6 +220,40 @@ describe('StudentRubricCard — cell language (Slice 1)', () => {
     const edHeader = screen.getByText('Exhibiting Depth').closest('th');
     expect(edHeader).toHaveStyle({ background: '#bfdbfe', color: '#1a1a1a' });
   });
+
+  it('renders a synced final cell with its final fill, 2px final border, bold, black text', () => {
+    const s = { ...makeStudent(), scores: { t1: { grade: 'ED', points: 100 } } };
+    renderCard({ student: s });
+    const cell = screen.getByTitle('Set Topic 1 to Exhibiting Depth');
+    expect(cell).toHaveStyle({
+      background: '#bfdbfe', border: '2px solid #2563eb', color: '#1a1a1a', fontWeight: '700',
+    });
+    expect(cell).toHaveTextContent('ED');
+  });
+
+  it('renders a pending draft cell with its draft fill, 2px draft border, black text', () => {
+    renderCard(); // empty scores
+    fireEvent.click(screen.getByTitle('Set Topic 1 to Developing'));
+    const cell = screen.getByTitle('Set Topic 1 to Developing');
+    expect(cell).toHaveStyle({
+      background: '#fefce8', border: '2px solid #fcd34d', color: '#1a1a1a',
+    });
+  });
+
+  it('renders an empty cell with the default card background and no level code', () => {
+    renderCard();
+    const cell = screen.getByTitle('Set Topic 1 to Emerging');
+    expect(cell).toHaveStyle({ background: 'var(--card-bg)' });
+    expect(cell).toHaveTextContent('');
+  });
+
+  it('renders the overridden synced final as empty when a draft is pending on another cell', () => {
+    const s = { ...makeStudent(), scores: { t1: { grade: 'ED', points: 100 } } };
+    renderCard({ student: s });
+    fireEvent.click(screen.getByTitle('Set Topic 1 to Developing')); // draft on D
+    const oldFinal = screen.getByTitle('Set Topic 1 to Exhibiting Depth'); // ED
+    expect(oldFinal).toHaveStyle({ background: 'var(--card-bg)' });
+  });
 });
 
 describe('StudentRubricCard review flag (#20)', () => {

--- a/client/src/pages/AssessmentSummaryPage.test.jsx
+++ b/client/src/pages/AssessmentSummaryPage.test.jsx
@@ -655,6 +655,91 @@ describe('StudentRubricCard — card chrome (Slice 5)', () => {
   });
 });
 
+describe('AssessmentSummaryPage — header + Reviewer Analysis (Slice 6)', () => {
+  function makeData() {
+    return {
+      assignment: { id: 50, schoology_assignment_id: '8', title: 'Quiz', mastery_grading_period_id: 1, mastery_grading_category_id: 2 },
+      topics: [{ id: 't1', title: 'Topic 1', category_title: 'Cat', external_id: 'X1' }],
+      students: [{ ...makeStudent(), id: 1, schoology_uid: 'uid-1', enrollment_id: 'enr-1', scores: {} }],
+    };
+  }
+  function renderPage() {
+    return render(
+      <MemoryRouter initialEntries={['/course/4/assessment/8']}>
+        <Routes>
+          <Route path="/course/:id/assessment/:assignmentId" element={<AssessmentSummaryPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+  }
+
+  it('removes the stale proficiency legend', async () => {
+    getMasteryForAssignment.mockResolvedValue(makeData());
+    renderPage();
+    await screen.findByText('Quiz');
+    expect(screen.queryByText(/green border = pending/)).not.toBeInTheDocument();
+  });
+
+  it('does not render the Reviewer Analysis button when no analysis exists', async () => {
+    getMasteryForAssignment.mockResolvedValue(makeData());
+    getFeedbackForAssignment.mockResolvedValue({});
+    getAssessmentAnalysis.mockResolvedValue(null);
+    renderPage();
+    await screen.findByText('Quiz');
+    expect(screen.queryByRole('button', { name: /reviewer analysis/i })).not.toBeInTheDocument();
+  });
+
+  it('renders the button when at least one feedback row exists', async () => {
+    getMasteryForAssignment.mockResolvedValue(makeData());
+    getFeedbackForAssignment.mockResolvedValue({ 1: { feedback_parsed: { rubric_scores: { X1: 'ED' } } } });
+    getAssessmentAnalysis.mockResolvedValue(null);
+    renderPage();
+    expect(await screen.findByRole('button', { name: /reviewer analysis/i })).toBeInTheDocument();
+  });
+
+  it('renders the button when an analysis record exists even without feedback rows', async () => {
+    getMasteryForAssignment.mockResolvedValue(makeData());
+    getFeedbackForAssignment.mockResolvedValue({});
+    getAssessmentAnalysis.mockResolvedValue({ analysis_parsed: { noticings: [] } });
+    renderPage();
+    expect(await screen.findByRole('button', { name: /reviewer analysis/i })).toBeInTheDocument();
+  });
+
+  it('opens the drawer with the not-student-facing tag and closes via ✕', async () => {
+    getMasteryForAssignment.mockResolvedValue(makeData());
+    getFeedbackForAssignment.mockResolvedValue({ 1: { feedback_parsed: { rubric_scores: { X1: 'ED' } } } });
+    getAssessmentAnalysis.mockResolvedValue({ analysis_parsed: { noticings: [] } });
+    renderPage();
+    fireEvent.click(await screen.findByRole('button', { name: /reviewer analysis/i }));
+    expect(screen.getByText('not student-facing')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /close reviewer analysis/i }));
+    await waitFor(() => expect(screen.queryByText('not student-facing')).not.toBeInTheDocument());
+  });
+
+  it('shows the proposed distribution computed from feedback and the noticings', async () => {
+    const data = makeData();
+    getMasteryForAssignment.mockResolvedValue(data);
+    getFeedbackForAssignment.mockResolvedValue({
+      1: { feedback_parsed: { rubric_scores: { X1: 'ED' } } },
+      2: { feedback_parsed: { rubric_scores: { X1: 'EX' } } },
+    });
+    getAssessmentAnalysis.mockResolvedValue({
+      analysis_parsed: {
+        noticings: [{ title: 'AI tool use', body: 'Half the class used AI.' }],
+        moderation_note: 'Worth a spot-check.',
+      },
+    });
+    renderPage();
+    fireEvent.click(await screen.findByRole('button', { name: /reviewer analysis/i }));
+
+    expect(screen.getByText(/From the reviewer's suggested grades/)).toBeInTheDocument();
+    expect(screen.getByText(/1 ED/)).toBeInTheDocument();
+    expect(screen.getByText('AI tool use')).toBeInTheDocument();
+    expect(screen.getByText('Half the class used AI.')).toBeInTheDocument();
+    expect(screen.getByText(/Worth a spot-check/)).toBeInTheDocument();
+  });
+});
+
 describe('AssessmentSummaryPage — feedback load (Slice 4)', () => {
   function makeData() {
     return {

--- a/client/src/pages/AssessmentSummaryPage.test.jsx
+++ b/client/src/pages/AssessmentSummaryPage.test.jsx
@@ -214,6 +214,14 @@ describe('StudentRubricCard draft persistence', () => {
   });
 });
 
+describe('StudentRubricCard — cell language (Slice 1)', () => {
+  it('renders each level header with its header-tint fill and black text', () => {
+    renderCard();
+    const edHeader = screen.getByText('Exhibiting Depth').closest('th');
+    expect(edHeader).toHaveStyle({ background: '#bfdbfe', color: '#1a1a1a' });
+  });
+});
+
 describe('StudentRubricCard review flag (#20)', () => {
   it('shows a "Flag for review" button when there is no review flag', () => {
     renderCard();

--- a/client/src/pages/AssessmentSummaryPage.test.jsx
+++ b/client/src/pages/AssessmentSummaryPage.test.jsx
@@ -448,6 +448,51 @@ describe('StudentRubricCard — in-place save (#50)', () => {
   });
 });
 
+describe('StudentRubricCard — rubric interaction (Slice 2)', () => {
+  it('clears a pending draft when its cell is clicked again', () => {
+    renderCard();
+    const cell = screen.getByTitle('Set Topic 1 to Developing');
+    fireEvent.click(cell);
+    expect(screen.getByText('1 pending change')).toBeInTheDocument();
+    fireEvent.click(cell);
+    expect(screen.queryByText(/pending change/)).not.toBeInTheDocument();
+  });
+
+  it('stages a synced final for removal on click, showing the red removal marker', () => {
+    const s = { ...makeStudent(), scores: { t1: { grade: 'ED', points: 100 } } };
+    renderCard({ student: s });
+    const finalCell = screen.getByTitle('Set Topic 1 to Exhibiting Depth'); // ED
+    fireEvent.click(finalCell);
+    expect(screen.getByText('1 pending change')).toBeInTheDocument();
+    expect(finalCell).toHaveStyle({ outline: '1.5px dashed #ef4444' });
+    expect(finalCell).toHaveTextContent('✕');
+  });
+
+  it('unstages a removal when the staged final cell is clicked again', () => {
+    const s = { ...makeStudent(), scores: { t1: { grade: 'ED', points: 100 } } };
+    renderCard({ student: s });
+    const finalCell = screen.getByTitle('Set Topic 1 to Exhibiting Depth');
+    fireEvent.click(finalCell); // stage removal
+    fireEvent.click(finalCell); // unstage
+    expect(screen.queryByText(/pending change/)).not.toBeInTheDocument();
+    expect(finalCell).toHaveStyle({ background: '#bfdbfe' }); // back to final fill
+  });
+
+  it('omits a removal-staged topic from the Schoology grade payload', async () => {
+    const s = { ...makeStudent(), scores: { t1: { grade: 'ED', points: 100 } } };
+    const onSaved = vi.fn();
+    renderCard({ student: s, onSaved });
+    fireEvent.click(screen.getByTitle('Set Topic 1 to Exhibiting Depth')); // stage removal of ED
+    fireEvent.click(screen.getByRole('button', { name: 'Update Schoology' }));
+
+    await waitFor(() => expect(writeMasteryScores).toHaveBeenCalled());
+    const payload = writeMasteryScores.mock.calls[0][1];
+    expect(payload.gradeInfo.t1).toBeUndefined(); // topic cleared → not in the replace set
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+    expect(onSaved.mock.calls[0][1].scores.t1).toBeUndefined();
+  });
+});
+
 describe('AssessmentSummaryPage — Send all bar (#51)', () => {
   function makeData() {
     return {

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -127,6 +127,8 @@ export const getCourseAnalytics = (id) => request(`/analytics/course/${id}`);
 // Feedback
 export const getFeedback = (params) => { const qs = new URLSearchParams(params).toString(); return request(`/feedback${qs ? `?${qs}` : ''}`); };
 export const getFeedbackItem = (id) => request(`/feedback/${id}`);
+export const getFeedbackForAssignment = (assignmentId) => request(`/feedback/for-assignment/${assignmentId}`);
+export const getAssessmentAnalysis = (assignmentId) => request(`/feedback/analysis/${assignmentId}`);
 export const updateFeedback = (id, data) => request(`/feedback/${id}`, { method: 'PUT', body: JSON.stringify(data) });
 export const approveFeedback = (id) => request(`/feedback/${id}/approve`, { method: 'PUT' });
 export const requestRevision = (id, notes) => request(`/feedback/${id}/request-revision`, { method: 'PUT', body: JSON.stringify({ teacher_notes: notes }) });

--- a/docs/superpowers/specs/2026-06-04-prismcp-ui-design.md
+++ b/docs/superpowers/specs/2026-06-04-prismcp-ui-design.md
@@ -1,0 +1,258 @@
+# PrisMCP UI — surfacing reviewer suggestions on the assessment page
+
+**Date:** 2026-06-04
+**Related issues:** extends/supersedes [#64](https://github.com/ganolan/prism/issues/64); follow-up [#78](https://github.com/ganolan/prism/issues/78)
+**Visual source of truth:** `docs/ui-design/PrisMCP-update/mockups/` (the build must match these closely)
+**Sample input:** `docs/ui-design/PrisMCP-update/ai-assisted-grading-output-sample.md`
+
+## Scope
+
+This is **Project A — the UI layer only**. It renders reviewer suggestions, flags, and
+assessment-wide noticings that already exist in the local `feedback` table (and a small new
+`assessment_analysis` record). It is independent of *how* those rows arrive.
+
+Out of scope, tracked separately:
+
+- **PrisMCP (Project B)** — the MCP server that lets an external grading agent read roster/draft
+  data and write suggestions into the DB (two-way). Its own brainstorm/spec. The UI here is the
+  render target for whatever PrisMCP writes; nothing in this spec depends on it (the existing
+  `inbox/` JSON ingestion can seed the same rows for development).
+- **Final-grade distribution + unified Analysis drawer** — [#78](https://github.com/ganolan/prism/issues/78).
+- **Descriptor text replacing ED/EX codes in cells** — a future update. The cell language here is
+  built so it already works with descriptor text (see mockup 01, second table), but wiring the
+  descriptors in is not part of this work.
+
+This supersedes the surfacing approach in the #64 spec. The one behavioural change from #64: a
+suggestion overlay is **never suppressed** when a cell is already current/pending — teacher marks
+and suggestions must coexist (see §3).
+
+## Mockups (visual source of truth)
+
+| File | Covers |
+|---|---|
+| `mockups/01-rubric-cell-language.html` | Three-way cell language: final / draft / suggestion, incl. the agree-case |
+| `mockups/02-student-card.html` | Per-student card: flags strip, hero comment, control band, suggestion box |
+| `mockups/03-reviewer-analysis-drawer.html` | Sticky header, conditional Reviewer Analysis button, drawer |
+| `mockups/04-noticings-panel-and-placements.html` | Noticings panel content + placement exploration |
+
+These are static HTML built during brainstorming. CSS values below are authoritative; where this
+doc and a mockup disagree, this doc wins, but they should not disagree.
+
+> **Local-only:** the `docs/ui-design/PrisMCP-update/` folder (these mockups and the grading
+> sample) is **gitignored** because it contains real student names and grades. The files live on
+> disk at the paths above for reference but are not in git history. This spec carries every
+> authoritative value, so the build does not depend on the mockups being committed.
+
+## 1. Colour system
+
+Replaces the current "all selections solid green" scheme. The rubric keeps its colours **inline**
+(as today's `LEVEL_COLORS` does) rather than moving to `app.css` tokens — a deliberate local
+exception, consistent with the existing rubric code and the #64 note.
+
+Per measurement level, five families. **Header tint = final fill.** Cell text is always
+**black (`#1a1a1a`)** because descriptor text will later replace the level codes, so colour cannot
+carry meaning in the text.
+
+| Level | Header & Final fill | Draft fill | Final border (2px solid) | Draft border (2px solid) |
+|---|---|---|---|---|
+| ED | `#bfdbfe` | `#eff6ff` | `#2563eb` | `#93c5fd` |
+| EX | `#bbf7d0` | `#f0fdf4` | `#16a34a` | `#86efac` |
+| D  | `#fef08a` | `#fefce8` | `#ca8a04` | `#fcd34d` |
+| EM | `#fed7aa` | `#fff7ed` | `#ea580c` | `#fdba74` |
+| IE | `#fecaca` | `#fef2f2` | `#dc2626` | `#fca5a5` |
+
+**Suggestion accent (violet — deliberately *not* yellow, because Developing is already yellow):**
+
+- Cell fill (suggestion present, no teacher mark): `#ede9fe`
+- Dashed ring: `1px dashed #a78bfa`, drawn with `outline` + `outline-offset: -3px` so it nests ~1px inside the cell border
+- ✦ glyph: `#8b5cf6`
+- The suggested-comment box and the Reviewer Analysis accents reuse this violet so a teacher's eye
+  correlates "violet cell hint" ↔ "violet comment suggestion" ↔ "Reviewer Analysis".
+
+## 2. Rubric cell language
+
+Header row: each level header uses its **Header tint**, black text, with the short label
+(`Exhibiting Depth`, etc.) beneath the code — as today.
+
+Body cell states and precedence (a cell can be in several at once):
+
+- **Final** — `background: <Header/Final fill>`, `border: 2px solid <Final border>`, `font-weight: 700`.
+- **Draft** — `background: <Draft fill>`, `border: 2px solid <Draft border>`.
+- **Suggestion** — `outline: 1px dashed #a78bfa; outline-offset: -3px;` plus, *when there is no
+  teacher mark in that cell*, `background: #ede9fe`; plus the ✦ glyph top-right.
+- **Empty** — default card background, 1px grey grid border.
+
+**Coexistence (the core rule).** Teacher mark and suggestion never replace each other:
+
+- Usually they fall on different cells in a row (teacher picked one level, the agent suggested
+  another) and simply sit side by side.
+- When they fall on the **same** cell (the agree-case), the cell renders **all three at once**:
+  the teacher's solid border on the perimeter, the dashed violet ring nested ~1px inside it, and
+  the ✦. The teacher's fill wins (no violet wash over a finalized cell). See mockup 01, Row 1 —
+  cell class `f-ED ai`.
+
+**Implementation notes:**
+
+- The colored 2px borders must override the grey grid line. Scope the selectors so they beat the
+  base `.rub td` rule (e.g. `.rub td.f-ED`, not `.f-ED`) — a plain class loses on specificity to
+  `.rub td` and the border silently won't render.
+- Bordered cells need `position: relative; z-index: 2` so the colored border paints over a
+  neighbouring header/cell border at shared corners (collapsed-border paint precedence).
+
+## 3. Rubric interaction
+
+Current behaviour: click a cell → set `pending` (draft); clicking again does nothing; finals can't
+be cleared from the UI. New behaviour:
+
+- **Clear a draft** — clicking the already-drafted cell again **clears** that topic's pending
+  selection (toggle off, back to default/whatever the synced state is).
+- **Stage a final for removal** — clicking a cell that is currently a synced **final** stages its
+  removal: the cell drops all colour back to default and shows a **removal marker** —
+  `outline: 1.5px dashed #ef4444; outline-offset: -3px;` + a small red `✕` top-right — so a staged
+  removal is visibly a *pending change*, distinct from a never-set cell. On **Update Schoology**,
+  the score is cleared in Schoology. (Mockup 02, "Proposed rubric click behavior".)
+
+Accepting a suggestion is just a normal cell click on the suggested level → flows into `pending` →
+draft → Update Schoology. There is **no "Accept rubric" button** — making the teacher click each
+cell keeps them deliberating on the proposed proficiency. Removal staging participates in the same
+`pending`/draft/`Update Schoology` lifecycle.
+
+## 4. Per-student card (`StudentRubricCard`)
+
+Top-to-bottom (mockup 02):
+
+1. **Reviewer flags strip** — *above* the rubric. One generic, collapsible `<details>` strip,
+   default **collapsed**, subtle amber (`#fffbef` / border `#e6c98a`, summary text `#92740f`).
+   Label: `⚑ Reviewer flags` with **no count** (the flags are free-form prose, not enumerable —
+   see the sample, where one student appears under several themes). Body = the prose from the
+   feedback row's `reviewer_flags`. The strip renders only when `reviewer_flags` is present.
+2. **Rubric** — the grid from §2/§3.
+3. **Overall Comment** — the hero. Bolder label, larger textarea (`font-size: 0.84rem`,
+   `1.5px` border). Teacher's editable comment, draft-persisted as today.
+4. **Control band** — directly under the comment (creates the boundary that makes the comment the
+   focus). Left-to-right:
+   - `Update Schoology` (primary)
+   - **Display to student** — reduced to an **eye icon + the toggle switch**, `title="Display to student"` (no text label)
+   - **Discard changes** — a **trash icon**, `title="Discard changes"`, **always shown**, greyed/disabled when no pending changes
+   - `↑ Use suggestion` — violet; copies the suggested feedback **up** into the comment textarea
+     (overwrites); appears **only when a suggestion exists**
+5. **Suggested feedback** box — below the band. Quiet and **unbranded**: no "AI", no "not yet
+   applied". Muted grey-violet (`#faf9fd` / border `#e6e1f3`), small header `✦ Suggested feedback`,
+   body text `#716b85`. Read-only. Renders only when a suggestion exists.
+
+`Use suggestion` runs the text through the existing `normalizePastedText()` before applying, to
+match pasted-comment cleaning, and overwrites the current comment.
+
+## 5. Data model & endpoints
+
+### Per-student suggestions
+
+Reuse the existing `feedback` table. Relevant `feedback_json` shape the UI reads per row:
+
+```jsonc
+{
+  "narrative_feedback": "string",                 // → Suggested feedback box / Use suggestion
+  "rubric_scores": { "<topic key>": "ED|EX|D|EM|IE" }, // → rubric suggestion overlay
+  "reviewer_flags": "string (prose) | null",      // → Reviewer flags strip
+  "strengths": ["..."], "suggestions": ["..."]    // optional, already supported
+}
+```
+
+`rubric_scores` → measurement-topic mapping (carried from #64): match each key against the topic's
+`external_id` first, then `title` (case-insensitive); value must be one of `ED/EX/D/EM/IE`.
+Unmatched keys or out-of-set values are ignored for the overlay (logged, never blocking).
+
+**Load:** add `GET /api/feedback/for-assignment/:assignmentId` → all `status IN ('draft',
+'teacher_modified')` rows for the assignment, keyed by `student_id`, each with parsed
+`feedback_parsed`. One request per assessment page, mirroring how mastery loads via
+`GET /api/mastery/:courseId/assignment/:assignmentId`. `AssessmentSummaryPage` fetches it alongside
+`getMasteryForAssignment` and hands each card its row.
+
+### Assessment-wide noticings
+
+The **proposed score distribution** needs no new storage — it is **computed client-side** by
+aggregating the loaded `feedback_parsed.rubric_scores` across students, per topic.
+
+The **prose noticings** (AI-use pattern, integrity, structural notes) and the optional
+**moderation note** are assessment-level. Add a minimal record:
+
+```
+assessment_analysis
+├── assignment_id INTEGER PK REFERENCES assignments(id)
+├── analysis_json TEXT NOT NULL   -- { noticings: [{title, body}], moderation_note?: string }
+├── created_at TEXT
+└── updated_at TEXT
+```
+
+Read via `GET /api/feedback/analysis/:assignmentId` (returns the parsed record or `null`).
+Population is shared with Project B; for development it is seeded by extending the existing inbox
+ingestion to capture the grading output's "Teacher Summary" block. (Ingestion changes beyond the
+read contract are out of scope here.)
+
+## 6. Reviewer Analysis drawer
+
+On `/assessment/:id` (mockups 03, 04):
+
+- **Sticky page header.** Make the existing header (`AssessmentSummaryPage.jsx` ~L862–881) sticky
+  so it stays on scroll. **Remove the proficiency legend block** (~L883–898) — every rubric already
+  shows the level headers, and the legend's hint text (`green border = pending · solid green =
+  current`) is now stale.
+- **Button.** Add `✦ Reviewer Analysis` at the right of the header (violet:
+  `#ede9fe`/`#c4b5fd`/`#6d28d9`). It renders **only when an agent analysis exists** for the
+  assignment — i.e. at least one draft/`teacher_modified` feedback row and/or an
+  `assessment_analysis` record. **No presence dot.**
+- **Drawer.** Slides in from the right over a dimmed overlay; closes via ✕ or overlay click.
+  Header tagged **not student-facing**. Contents, top to bottom:
+  1. **✦ Proposed score distribution** — one horizontal stacked bar per measurement topic, segments
+     coloured by the level Header tints, each labelled with its count. A one-line clarifier:
+     *"From the reviewer's suggested grades — not final entered scores."* Optional amber moderation
+     note beneath (from `analysis_json.moderation_note`).
+  2. **Noticings** — the prose blocks from `analysis_json.noticings` (title + body each).
+
+## 7. Two-way flow
+
+No new UI. A teacher types a draft comment / sets draft proficiencies; an external agent (via
+PrisMCP, Project B) reads them and writes an updated `feedback` row; it surfaces through the exact
+same Suggested-feedback box and rubric overlay defined above. The UI is symmetric by construction.
+
+## 8. Status lifecycle
+
+- Accepting a suggestion (cell click) or `Use suggestion` produces `pending` changes → card shows
+  Update Schoology enabled (as today).
+- On successful Update Schoology, flip the row's status: any teacher edit/accept → `teacher_modified`;
+  a completed Update Schoology → `approved`. `approved` rows are filtered out server-side (§5) so
+  they stop re-surfacing as suggestions.
+
+## 9. Testing
+
+- **Server:** `GET /api/feedback/for-assignment/:assignmentId` returns parsed rows keyed by
+  `student_id`, excludes `approved`; `GET /api/feedback/analysis/:assignmentId` returns the parsed
+  record or `null`.
+- **Client (`AssessmentSummaryPage.test.jsx`):**
+  - Suggestion overlay renders for a resolvable `rubric_scores` entry and **coexists** with a
+    current/pending mark on the same row (agree-case keeps solid border + dashed ring + ✦).
+  - Clicking a drafted cell again clears it; clicking a final stages removal (removal marker shown).
+  - Suggested-feedback box + `↑ Use suggestion` appear only when a suggestion exists; Use suggestion
+    overwrites the comment with normalized text and arms pending changes.
+  - Reviewer flags strip renders only when `reviewer_flags` present; default collapsed.
+  - Reviewer Analysis button renders only when an analysis exists; drawer shows the computed
+    proposed distribution and the noticings; absent otherwise.
+  - An unresolvable `rubric_scores` key renders no overlay and does not throw.
+
+## 10. Verification
+
+- `cd client && npx vite build`
+- `npx vitest run server/`
+- `npx vitest run client/src/pages/AssessmentSummaryPage.test.jsx`
+- Manual: seed a draft feedback row (+ an `assessment_analysis` record) for an assignment, open
+  `/assessment/:id`, confirm the cell language, the coexisting agree-case, clear-draft and
+  stage-removal interactions, the suggestion box + Use suggestion, the reviewer-flags strip, and the
+  Reviewer Analysis drawer with the proposed distribution + noticings. Compare against the mockups.
+
+## Out of scope
+
+- PrisMCP server / ingestion beyond the read contract (Project B).
+- Final-grade distribution and the unified neutral-`Analysis` ↔ violet-`Reviewer Analysis` drawer
+  ([#78](https://github.com/ganolan/prism/issues/78)).
+- Descriptor text replacing level codes in cells (future; cell language is already compatible).
+- Bulk "accept all suggestions" across students.

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -175,6 +175,16 @@ CREATE TABLE IF NOT EXISTS inbox_log (
   processed_at TEXT DEFAULT (datetime('now'))
 );
 
+-- Assessment-level reviewer analysis (PrisMCP Project A). One row per assignment.
+-- analysis_json holds { noticings: [{title, body}], moderation_note?: string }.
+-- Populated by Project B / inbox ingestion (out of scope here); read-only in the UI.
+CREATE TABLE IF NOT EXISTS assessment_analysis (
+  assignment_id INTEGER PRIMARY KEY REFERENCES assignments(id),
+  analysis_json TEXT NOT NULL,
+  created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now'))
+);
+
 -- Folders (unit/topic structure)
 CREATE TABLE IF NOT EXISTS folders (
   id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -318,3 +318,4 @@ CREATE INDEX IF NOT EXISTS idx_completion_student ON completion(student_id);
 CREATE INDEX IF NOT EXISTS idx_completion_course ON completion(course_id);
 CREATE INDEX IF NOT EXISTS idx_grading_categories_course ON grading_categories(course_id);
 CREATE INDEX IF NOT EXISTS idx_assignment_assignees_uid ON assignment_assignees(schoology_uid);
+CREATE INDEX IF NOT EXISTS idx_assessment_analysis_assignment ON assessment_analysis(assignment_id);

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -318,4 +318,3 @@ CREATE INDEX IF NOT EXISTS idx_completion_student ON completion(student_id);
 CREATE INDEX IF NOT EXISTS idx_completion_course ON completion(course_id);
 CREATE INDEX IF NOT EXISTS idx_grading_categories_course ON grading_categories(course_id);
 CREATE INDEX IF NOT EXISTS idx_assignment_assignees_uid ON assignment_assignees(schoology_uid);
-CREATE INDEX IF NOT EXISTS idx_assessment_analysis_assignment ON assessment_analysis(assignment_id);

--- a/server/routes/feedback.js
+++ b/server/routes/feedback.js
@@ -13,6 +13,46 @@ router.get('/inbox-log', (req, res) => {
   res.json(rows);
 });
 
+// GET /api/feedback/for-assignment/:assignmentId — all draft/teacher_modified
+// feedback rows for one assignment, keyed by student_id, each with parsed JSON.
+// :assignmentId is the SCHOOLOGY assignment id (matches the assessment page URL
+// + the mastery route); resolved to the local assignment id internally.
+// Must be registered before GET /:id (catch-all). approved rows are excluded so
+// they stop re-surfacing as suggestions.
+router.get('/for-assignment/:assignmentId', (req, res) => {
+  const db = getDb();
+  const assignment = db.prepare(
+    'SELECT id FROM assignments WHERE schoology_assignment_id = ?'
+  ).get(req.params.assignmentId);
+  if (!assignment) return res.json({});
+  const rows = db.prepare(`
+    SELECT * FROM feedback
+    WHERE assignment_id = ? AND status IN ('draft', 'teacher_modified')
+  `).all(assignment.id);
+  const byStudent = {};
+  for (const row of rows) {
+    row.feedback_parsed = JSON.parse(row.feedback_json || '{}');
+    byStudent[row.student_id] = row;
+  }
+  res.json(byStudent);
+});
+
+// GET /api/feedback/analysis/:assignmentId — the assessment_analysis record for
+// one assignment (Schoology id), parsed, or null. Must precede GET /:id.
+router.get('/analysis/:assignmentId', (req, res) => {
+  const db = getDb();
+  const assignment = db.prepare(
+    'SELECT id FROM assignments WHERE schoology_assignment_id = ?'
+  ).get(req.params.assignmentId);
+  if (!assignment) return res.json(null);
+  const row = db.prepare(
+    'SELECT * FROM assessment_analysis WHERE assignment_id = ?'
+  ).get(assignment.id);
+  if (!row) return res.json(null);
+  row.analysis_parsed = JSON.parse(row.analysis_json || '{}');
+  res.json(row);
+});
+
 // GET /api/feedback — list feedback with filters
 router.get('/', (req, res) => {
   const db = getDb();

--- a/server/routes/feedback.test.js
+++ b/server/routes/feedback.test.js
@@ -1,0 +1,105 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import express from 'express';
+
+vi.hoisted(() => { process.env.DB_PATH = ':memory:'; });
+
+import router from './feedback.js';
+import { getDb } from '../db/index.js';
+
+function startServer() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/feedback', router);
+  const server = app.listen(0);
+  return { server, port: server.address().port };
+}
+
+async function call(method, path, payload) {
+  const { server, port } = startServer();
+  try {
+    const res = await fetch(`http://localhost:${port}${path}`, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: payload ? JSON.stringify(payload) : undefined,
+    });
+    const text = await res.text();
+    let body = null;
+    if (text) { try { body = JSON.parse(text); } catch { body = text; } }
+    return { status: res.status, body };
+  } finally {
+    server.close();
+  }
+}
+
+let courseId, assignmentSchoolId, localAssignmentId, s1, s2;
+
+beforeEach(() => {
+  const db = getDb();
+  db.exec(
+    'DELETE FROM assessment_analysis; DELETE FROM feedback; DELETE FROM assignments; ' +
+    'DELETE FROM students; DELETE FROM courses;'
+  );
+  courseId = db.prepare(
+    `INSERT INTO courses (schoology_section_id, course_name) VALUES ('sec-1', 'Course')`
+  ).run().lastInsertRowid;
+  assignmentSchoolId = 'sa-1';
+  localAssignmentId = db.prepare(
+    `INSERT INTO assignments (course_id, schoology_assignment_id, title) VALUES (?, ?, 'Project')`
+  ).run(courseId, assignmentSchoolId).lastInsertRowid;
+  s1 = db.prepare(`INSERT INTO students (schoology_uid, first_name, last_name) VALUES ('u1','Ada','Lovelace')`).run().lastInsertRowid;
+  s2 = db.prepare(`INSERT INTO students (schoology_uid, first_name, last_name) VALUES ('u2','Alan','Turing')`).run().lastInsertRowid;
+});
+
+function insertFeedback(studentId, status, json) {
+  return getDb().prepare(
+    `INSERT INTO feedback (student_id, assignment_id, status, feedback_json) VALUES (?, ?, ?, ?)`
+  ).run(studentId, localAssignmentId, status, JSON.stringify(json)).lastInsertRowid;
+}
+
+describe('GET /api/feedback/for-assignment/:assignmentId', () => {
+  test('returns draft + teacher_modified rows keyed by student_id with parsed feedback', async () => {
+    insertFeedback(s1, 'draft', { narrative_feedback: 'Great', rubric_scores: { 'X1': 'ED' } });
+    insertFeedback(s2, 'teacher_modified', { narrative_feedback: 'Good', reviewer_flags: 'placeholder remains' });
+    const { status, body } = await call('GET', `/api/feedback/for-assignment/${assignmentSchoolId}`);
+    expect(status).toBe(200);
+    expect(Object.keys(body).sort()).toEqual([String(s1), String(s2)].sort());
+    expect(body[s1].feedback_parsed.rubric_scores).toEqual({ X1: 'ED' });
+    expect(body[s2].feedback_parsed.reviewer_flags).toBe('placeholder remains');
+  });
+
+  test('excludes approved rows', async () => {
+    insertFeedback(s1, 'approved', { narrative_feedback: 'done' });
+    const { body } = await call('GET', `/api/feedback/for-assignment/${assignmentSchoolId}`);
+    expect(body[s1]).toBeUndefined();
+  });
+
+  test('returns an empty object for an unknown assignment', async () => {
+    const { status, body } = await call('GET', '/api/feedback/for-assignment/nope');
+    expect(status).toBe(200);
+    expect(body).toEqual({});
+  });
+});
+
+describe('GET /api/feedback/analysis/:assignmentId', () => {
+  test('returns the parsed analysis record when present', async () => {
+    const analysis = { noticings: [{ title: 'AI use', body: 'half the class' }], moderation_note: 'spot-check' };
+    getDb().prepare(
+      'INSERT INTO assessment_analysis (assignment_id, analysis_json) VALUES (?, ?)'
+    ).run(localAssignmentId, JSON.stringify(analysis));
+    const { status, body } = await call('GET', `/api/feedback/analysis/${assignmentSchoolId}`);
+    expect(status).toBe(200);
+    expect(body.analysis_parsed).toEqual(analysis);
+  });
+
+  test('returns null when no analysis exists', async () => {
+    const { status, body } = await call('GET', `/api/feedback/analysis/${assignmentSchoolId}`);
+    expect(status).toBe(200);
+    expect(body).toBeNull();
+  });
+
+  test('returns null for an unknown assignment', async () => {
+    const { status, body } = await call('GET', '/api/feedback/analysis/nope');
+    expect(status).toBe(200);
+    expect(body).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Project A — the **UI layer** for PrisMCP. Surfaces reviewer (AI grading) suggestions, per-student reviewer flags, and assessment-wide noticings on `/assessment/:id`, rendering against the existing local `feedback` table plus one new `assessment_analysis` record. Implements the spec at `docs/superpowers/specs/2026-06-04-prismcp-ui-design.md` (extends/supersedes #64).

**Behavioural rule that matters:** a rubric suggestion is **never suppressed** when a cell is already current/pending — teacher marks and suggestions coexist (the agree-case renders the solid final border + nested dashed violet ring + ✦, with no violet wash over the final fill).

Built in 6 vertical slices, each TDD'd and independently reviewed (spec + quality):

1. **Cell language** — five per-level colour families (header tint = final fill, draft fill, 2px final/draft borders), black cell text, violet suggestion overlay, red staged-removal marker. Replaces the old "all green" scheme.
2. **Interaction** — click empty→draft; click a drafted cell→clears it; click a synced final→stages removal (cleared in Schoology on Update); click again→unstages. No "Accept rubric" button.
3. **Server** — new `assessment_analysis` table; `GET /api/feedback/for-assignment/:assignmentId` (draft/teacher_modified rows keyed by student, excludes `approved`) and `GET /api/feedback/analysis/:assignmentId`; both resolve the Schoology id → local id and precede the catch-all `/:id`.
4. **Page load + overlay** — `rubricSuggestions` resolver/distribution helper; parallel load of mastery + feedback + analysis (reviewer data degrades gracefully; mastery errors still surface); the violet suggestion overlay with coexistence.
5. **Card chrome** — reviewer-flags `<details>` strip, hero comment, control band (Update Schoology, eye-icon display toggle, always-shown trash discard, violet ↑ Use suggestion), unbranded suggested-feedback box.
6. **Drawer** — sticky header, proficiency legend removed, conditional `✦ Reviewer Analysis` button + right-side drawer with a client-computed proposed-score distribution + noticings.

**Out of scope (unchanged):** the PrisMCP MCP server / ingestion (Project B), the final-grade distribution + unified Analysis drawer (#78), descriptor-text-in-cells, and bulk accept-all.

## Test Plan

- [x] `npx vitest run server/` — 156 pass (incl. new `server/routes/feedback.test.js`)
- [x] `cd client && npx vitest run` — 197 pass (incl. `rubricSuggestions.test.js` + new `AssessmentSummaryPage.test.jsx` coverage: coexistence/agree-case, clear-draft, stage-removal, flags strip, Use suggestion overwrite, drawer distribution + noticings, conditional button)
- [x] `cd client && npx vite build` — succeeds
- [ ] Manual: seed a draft feedback row (+ an `assessment_analysis` record) for an assignment, open `/assessment/:id`, and compare against the mockups in `docs/ui-design/PrisMCP-update/mockups/` — cell language, agree-case coexistence, clear-draft/stage-removal, the suggestion box + Use suggestion, the reviewer-flags strip, and the Reviewer Analysis drawer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)