### PR TITLE
fix(sync): paginate section folders so courses with >20 folders sync fully

### DIFF
--- a/server/services/schoology.js
+++ b/server/services/schoology.js
@@ -109,8 +109,10 @@ export async function getUserProfile(uid) {
 }
 
 export async function getSectionFolders(sectionId) {
-  const data = await apiGet(`/sections/${sectionId}/folders`);
-  return data?.folders || data?.folder || [];
+  // Paginate: Schoology pages this endpoint at 20 items by default, so a single
+  // un-paginated GET silently drops the 21st+ folder (and every assignment in
+  // it falls into the "Ungrouped" bucket). The list wrapper key is `folders`.
+  return paginateGet(`/sections/${sectionId}/folders`, 'folders');
 }
 
 export async function getSectionGradingCategories(sectionId) {

--- a/server/services/schoology.test.js
+++ b/server/services/schoology.test.js
@@ -1,0 +1,55 @@
+import { describe, test, expect, vi, afterEach } from 'vitest';
+
+// schoology.js reads OAuth credentials from the environment at import time.
+// Seed harmless values BEFORE the module is dynamically imported (a static
+// import would be hoisted above these assignments). fetch is stubbed per-test,
+// so the real network is never touched.
+process.env.SCHOOLOGY_BASE_URL ||= 'https://api.schoology.com';
+process.env.SCHOOLOGY_CONSUMER_KEY ||= 'test-key';
+process.env.SCHOOLOGY_CONSUMER_SECRET ||= 'test-secret';
+
+function jsonResponse(body) {
+  return { ok: true, status: 200, headers: { get: () => null }, json: async () => body };
+}
+
+describe('getSectionFolders', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  // Regression for the dropped-folder bug: Schoology pages the folders endpoint
+  // at 20 items by default, so a single un-paginated GET silently truncates any
+  // course with more than 20 folders. The 21st+ folder (and every assignment in
+  // it) then disappears from grouped views.
+  test('paginates through every page instead of truncating at the default page size', async () => {
+    const { getSectionFolders } = await import('./schoology.js');
+
+    const page1 = { folders: Array.from({ length: 100 }, (_, i) => ({ id: i, title: `F${i}` })) };
+    const page2 = { folders: Array.from({ length: 5 }, (_, i) => ({ id: 100 + i, title: `F${100 + i}` })) };
+
+    const calls = [];
+    vi.stubGlobal('fetch', vi.fn(async (url) => {
+      calls.push(url);
+      return jsonResponse(url.includes('start=100') ? page2 : page1);
+    }));
+
+    const folders = await getSectionFolders('7899896088');
+
+    expect(folders).toHaveLength(105);
+    expect(folders.at(-1).id).toBe(104);
+    expect(calls.some((u) => u.includes('start=0'))).toBe(true);
+    expect(calls.some((u) => u.includes('start=100'))).toBe(true);
+  });
+
+  test('requests a page size large enough to clear the default 20-item cap', async () => {
+    const { getSectionFolders } = await import('./schoology.js');
+
+    const calls = [];
+    vi.stubGlobal('fetch', vi.fn(async (url) => {
+      calls.push(url);
+      return jsonResponse({ folders: [] });
+    }));
+
+    await getSectionFolders('123');
+
+    expect(calls[0]).toMatch(/limit=100/);
+  });
+});


### PR DESCRIPTION
## Problem
`getSectionFolders()` was the only Schoology list endpoint making a single **un-paginated** GET (every other list call uses `paginateGet`). Schoology pages `/sections/{id}/folders` at **20 items** by default, so any course with more than 20 folders silently dropped the 21st+ folder on every sync — and every assignment inside a dropped folder fell into the gradebook's **"Ungrouped"** bucket instead of its real folder group.

Surfaced by an aligned summative ("AP CSP: CPT4-5 Validation Test Reassessment - Result (S)") that appeared "missing" from the Assessments list. Its folder, "Episode 2 and Unit 3 Reassessment" (`998588607`), was the 21st folder in AP CSP and never synced.

## Fix
Route `getSectionFolders` through `paginateGet(..., 'folders')`. The list-wrapper key (`folders`) and `start`/`limit` support were verified against the live API before changing code.

## Tests
- New `server/services/schoology.test.js` — regression coverage for multi-page concatenation and the page-size parameter (red on old code, green after).
- Full server suite: 158/158 pass.

## Verification
Re-synced AP CSP folders end-to-end: all 21 folders now sync, `998588607` lands in the DB, and the assessment renders under its real folder header with the "Ungrouped" section gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)