### PR TITLE
feat(mcp): PrisMCP slice 2 — list_assignments

### DIFF
--- a/mcp/handlers.js
+++ b/mcp/handlers.js
@@ -14,3 +14,27 @@ export function listCourses(db) {
     ORDER BY course_name
   `).all();
 }
+
+// Assignments for a course (local course id), so a phrase like "the MAD
+// project I just collected" can resolve to a concrete assignment (spec §3.1).
+export function listAssignments(db, { course_id }) {
+  const rows = db.prepare(`
+    SELECT a.id, a.schoology_assignment_id, a.title, a.due_date, a.assignment_type,
+           EXISTS (
+             SELECT 1 FROM mastery_alignments ma
+             WHERE ma.assignment_schoology_id = a.schoology_assignment_id
+               AND ma.course_id = a.course_id
+           ) AS has_aligned_topics,
+           (SELECT MAX(g.submitted_at) FROM grades g WHERE g.assignment_id = a.id) AS latest_submitted_at
+    FROM assignments a
+    WHERE a.course_id = ?
+    ORDER BY a.due_date, a.id
+  `).all(Number(course_id));
+  return rows.map(({ latest_submitted_at, ...r }) => ({
+    ...r,
+    has_aligned_topics: !!r.has_aligned_topics,
+    // submitted_at is a Unix-seconds epoch (0 = never submitted, #13/#62);
+    // surface the latest as an ISO string, null when nobody has submitted.
+    latest_submission_at: latest_submitted_at > 0 ? new Date(latest_submitted_at * 1000).toISOString() : null,
+  }));
+}

--- a/mcp/handlers.test.js
+++ b/mcp/handlers.test.js
@@ -3,10 +3,14 @@ import { describe, test, expect, beforeEach, vi } from 'vitest';
 vi.hoisted(() => { process.env.DB_PATH = ':memory:'; });
 
 import { getDb } from '../server/db/index.js';
-import { listCourses } from './handlers.js';
+import { listCourses, listAssignments } from './handlers.js';
 
 beforeEach(() => {
-  getDb().exec('DELETE FROM courses;');
+  getDb().exec(
+    'DELETE FROM mastery_alignments; DELETE FROM measurement_topics; ' +
+    'DELETE FROM grades; DELETE FROM assignments; ' +
+    'DELETE FROM students; DELETE FROM courses;'
+  );
 });
 
 describe('listCourses', () => {
@@ -34,5 +38,39 @@ describe('listCourses', () => {
     db.prepare(`INSERT INTO courses (schoology_section_id, course_name, hidden) VALUES ('h', 'Hidden', 1)`).run();
     db.prepare(`INSERT INTO courses (schoology_section_id, course_name) VALUES ('ok', 'Active')`).run();
     expect(listCourses(db).map((c) => c.course_name)).toEqual(['Active']);
+  });
+});
+
+function seedCourse(db) {
+  return db.prepare(`INSERT INTO courses (schoology_section_id, course_name) VALUES ('s1', 'MAD')`).run().lastInsertRowid;
+}
+
+describe('listAssignments', () => {
+  test('has_aligned_topics reflects whether the assignment has a mastery alignment', () => {
+    const db = getDb();
+    const courseId = seedCourse(db);
+    db.prepare(`INSERT INTO assignments (course_id, schoology_assignment_id, title) VALUES (?, 'aligned', 'Aligned')`).run(courseId);
+    db.prepare(`INSERT INTO assignments (course_id, schoology_assignment_id, title) VALUES (?, 'bare', 'Bare')`).run(courseId);
+    db.prepare(`INSERT INTO measurement_topics (id, course_id) VALUES ('t1', ?)`).run(courseId);
+    db.prepare(`INSERT INTO mastery_alignments (assignment_schoology_id, topic_id, course_id) VALUES ('aligned', 't1', ?)`).run(courseId);
+
+    const byTitle = Object.fromEntries(listAssignments(db, { course_id: courseId }).map((a) => [a.title, a]));
+    expect(byTitle.Aligned.has_aligned_topics).toBe(true);
+    expect(byTitle.Bare.has_aligned_topics).toBe(false);
+  });
+
+  test('latest_submission_at is the max submitted_at as ISO, null when never submitted', () => {
+    const db = getDb();
+    const courseId = seedCourse(db);
+    const submittedId = db.prepare(`INSERT INTO assignments (course_id, schoology_assignment_id, title) VALUES (?, 'sub', 'Submitted')`).run(courseId).lastInsertRowid;
+    db.prepare(`INSERT INTO assignments (course_id, schoology_assignment_id, title) VALUES (?, 'untouched', 'Untouched')`).run(courseId);
+    const s1 = db.prepare(`INSERT INTO students (schoology_uid, first_name, last_name) VALUES ('u1','A','One')`).run().lastInsertRowid;
+    const s2 = db.prepare(`INSERT INTO students (schoology_uid, first_name, last_name) VALUES ('u2','B','Two')`).run().lastInsertRowid;
+    db.prepare(`INSERT INTO grades (student_id, assignment_id, submitted_at) VALUES (?, ?, 1700000000)`).run(s1, submittedId);
+    db.prepare(`INSERT INTO grades (student_id, assignment_id, submitted_at) VALUES (?, ?, 1700000500)`).run(s2, submittedId);
+
+    const byTitle = Object.fromEntries(listAssignments(db, { course_id: courseId }).map((a) => [a.title, a]));
+    expect(byTitle.Submitted.latest_submission_at).toBe(new Date(1700000500 * 1000).toISOString());
+    expect(byTitle.Untouched.latest_submission_at).toBeNull();
   });
 });

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -1,8 +1,9 @@
 import { pathToFileURL } from 'url';
+import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { getDb } from '../server/db/index.js';
-import { listCourses } from './handlers.js';
+import { listCourses, listAssignments } from './handlers.js';
 
 // <2KB tool-search hint (spec §3.4) so a client knows when to surface PrisMCP.
 export const INSTRUCTIONS =
@@ -33,6 +34,18 @@ export function createServer() {
     'list_courses',
     { description: 'List active (non-archived) Prism courses, to resolve which class to grade.' },
     async () => ({ content: [{ type: 'text', text: JSON.stringify(listCourses(getDb())) }] })
+  );
+
+  server.registerTool(
+    'list_assignments',
+    {
+      description:
+        "List a course's assignments (with aligned-topic + latest-submission hints) to resolve which assignment to grade.",
+      inputSchema: { course_id: z.union([z.number(), z.string()]).describe('Local Prism course id') },
+    },
+    async ({ course_id }) => ({
+      content: [{ type: 'text', text: JSON.stringify(listAssignments(getDb(), { course_id })) }],
+    })
   );
 
   return server;

--- a/mcp/server.test.js
+++ b/mcp/server.test.js
@@ -19,7 +19,10 @@ async function connect() {
 }
 
 beforeEach(() => {
-  getDb().exec('DELETE FROM courses;');
+  getDb().exec(
+    'DELETE FROM mastery_alignments; DELETE FROM grades; DELETE FROM assignments; ' +
+    'DELETE FROM students; DELETE FROM courses;'
+  );
 });
 
 describe('PrisMCP server', () => {
@@ -31,6 +34,18 @@ describe('PrisMCP server', () => {
     const res = await client.callTool({ name: 'list_courses', arguments: {} });
     const data = JSON.parse(res.content[0].text);
     expect(data.map((c) => c.course_name)).toEqual(['Robotics']);
+  });
+
+  test('exposes list_assignments scoped to the requested course', async () => {
+    const db = getDb();
+    const c1 = db.prepare(`INSERT INTO courses (schoology_section_id, course_name) VALUES ('s1', 'MAD')`).run().lastInsertRowid;
+    const c2 = db.prepare(`INSERT INTO courses (schoology_section_id, course_name) VALUES ('s2', 'ROB')`).run().lastInsertRowid;
+    db.prepare(`INSERT INTO assignments (course_id, schoology_assignment_id, title) VALUES (?, 'a1', 'App Project')`).run(c1);
+    db.prepare(`INSERT INTO assignments (course_id, schoology_assignment_id, title) VALUES (?, 'a2', 'Other Course Task')`).run(c2);
+    const client = await connect();
+    const res = await client.callTool({ name: 'list_assignments', arguments: { course_id: c1 } });
+    const data = JSON.parse(res.content[0].text);
+    expect(data.map((a) => a.title)).toEqual(['App Project']);
   });
 
   test('advertises the tool-search instructions to the client', async () => {


### PR DESCRIPTION
## Slice 2 of #84 (PrisMCP server) — stacked on #93

`list_assignments(course_id)` → each assignment with:
- `has_aligned_topics` — whether a `mastery_alignments` row exists for it (the rubric skeleton is present)
- `latest_submission_at` — `max(grades.submitted_at)` as an ISO string, `null` when nobody has submitted

First tool taking input (zod `inputSchema`). Lets the agent resolve "the project I just collected" to a concrete assignment.

### Verification
- `npx vitest run` → **166 passed** (8 MCP tests)
- Tests: integration (course-scoped dispatch via the MCP client) + handler units (has_aligned_topics true/false, latest_submission_at max-as-ISO / null).

> **Stacked PR:** base is `feat/prismcp-slice-1-skeleton` (#93), so the diff shows only slice 2. Merge #93 first; GitHub will retarget this onto `main`.

Closes #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)