### PR TITLE
feat(mcp): PrisMCP slice 3 — get_assignment_context + shared read services

### DIFF
--- a/mcp/handlers.js
+++ b/mcp/handlers.js
@@ -14,3 +14,27 @@ export function listCourses(db) {
     ORDER BY course_name
   `).all();
 }
+
+// Assignments for a course (local course id), so a phrase like "the MAD
+// project I just collected" can resolve to a concrete assignment (spec §3.1).
+export function listAssignments(db, { course_id }) {
+  const rows = db.prepare(`
+    SELECT a.id, a.schoology_assignment_id, a.title, a.due_date, a.assignment_type,
+           EXISTS (
+             SELECT 1 FROM mastery_alignments ma
+             WHERE ma.assignment_schoology_id = a.schoology_assignment_id
+               AND ma.course_id = a.course_id
+           ) AS has_aligned_topics,
+           (SELECT MAX(g.submitted_at) FROM grades g WHERE g.assignment_id = a.id) AS latest_submitted_at
+    FROM assignments a
+    WHERE a.course_id = ?
+    ORDER BY a.due_date, a.id
+  `).all(Number(course_id));
+  return rows.map(({ latest_submitted_at, ...r }) => ({
+    ...r,
+    has_aligned_topics: !!r.has_aligned_topics,
+    // submitted_at is a Unix-seconds epoch (0 = never submitted, #13/#62);
+    // surface the latest as an ISO string, null when nobody has submitted.
+    latest_submission_at: latest_submitted_at > 0 ? new Date(latest_submitted_at * 1000).toISOString() : null,
+  }));
+}

--- a/mcp/handlers.test.js
+++ b/mcp/handlers.test.js
@@ -3,10 +3,14 @@ import { describe, test, expect, beforeEach, vi } from 'vitest';
 vi.hoisted(() => { process.env.DB_PATH = ':memory:'; });
 
 import { getDb } from '../server/db/index.js';
-import { listCourses } from './handlers.js';
+import { listCourses, listAssignments } from './handlers.js';
 
 beforeEach(() => {
-  getDb().exec('DELETE FROM courses;');
+  getDb().exec(
+    'DELETE FROM mastery_alignments; DELETE FROM measurement_topics; ' +
+    'DELETE FROM grades; DELETE FROM assignments; ' +
+    'DELETE FROM students; DELETE FROM courses;'
+  );
 });
 
 describe('listCourses', () => {
@@ -34,5 +38,39 @@ describe('listCourses', () => {
     db.prepare(`INSERT INTO courses (schoology_section_id, course_name, hidden) VALUES ('h', 'Hidden', 1)`).run();
     db.prepare(`INSERT INTO courses (schoology_section_id, course_name) VALUES ('ok', 'Active')`).run();
     expect(listCourses(db).map((c) => c.course_name)).toEqual(['Active']);
+  });
+});
+
+function seedCourse(db) {
+  return db.prepare(`INSERT INTO courses (schoology_section_id, course_name) VALUES ('s1', 'MAD')`).run().lastInsertRowid;
+}
+
+describe('listAssignments', () => {
+  test('has_aligned_topics reflects whether the assignment has a mastery alignment', () => {
+    const db = getDb();
+    const courseId = seedCourse(db);
+    db.prepare(`INSERT INTO assignments (course_id, schoology_assignment_id, title) VALUES (?, 'aligned', 'Aligned')`).run(courseId);
+    db.prepare(`INSERT INTO assignments (course_id, schoology_assignment_id, title) VALUES (?, 'bare', 'Bare')`).run(courseId);
+    db.prepare(`INSERT INTO measurement_topics (id, course_id) VALUES ('t1', ?)`).run(courseId);
+    db.prepare(`INSERT INTO mastery_alignments (assignment_schoology_id, topic_id, course_id) VALUES ('aligned', 't1', ?)`).run(courseId);
+
+    const byTitle = Object.fromEntries(listAssignments(db, { course_id: courseId }).map((a) => [a.title, a]));
+    expect(byTitle.Aligned.has_aligned_topics).toBe(true);
+    expect(byTitle.Bare.has_aligned_topics).toBe(false);
+  });
+
+  test('latest_submission_at is the max submitted_at as ISO, null when never submitted', () => {
+    const db = getDb();
+    const courseId = seedCourse(db);
+    const submittedId = db.prepare(`INSERT INTO assignments (course_id, schoology_assignment_id, title) VALUES (?, 'sub', 'Submitted')`).run(courseId).lastInsertRowid;
+    db.prepare(`INSERT INTO assignments (course_id, schoology_assignment_id, title) VALUES (?, 'untouched', 'Untouched')`).run(courseId);
+    const s1 = db.prepare(`INSERT INTO students (schoology_uid, first_name, last_name) VALUES ('u1','A','One')`).run().lastInsertRowid;
+    const s2 = db.prepare(`INSERT INTO students (schoology_uid, first_name, last_name) VALUES ('u2','B','Two')`).run().lastInsertRowid;
+    db.prepare(`INSERT INTO grades (student_id, assignment_id, submitted_at) VALUES (?, ?, 1700000000)`).run(s1, submittedId);
+    db.prepare(`INSERT INTO grades (student_id, assignment_id, submitted_at) VALUES (?, ?, 1700000500)`).run(s2, submittedId);
+
+    const byTitle = Object.fromEntries(listAssignments(db, { course_id: courseId }).map((a) => [a.title, a]));
+    expect(byTitle.Submitted.latest_submission_at).toBe(new Date(1700000500 * 1000).toISOString());
+    expect(byTitle.Untouched.latest_submission_at).toBeNull();
   });
 });

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -1,8 +1,9 @@
 import { pathToFileURL } from 'url';
+import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { getDb } from '../server/db/index.js';
-import { listCourses } from './handlers.js';
+import { listCourses, listAssignments } from './handlers.js';
 
 // <2KB tool-search hint (spec §3.4) so a client knows when to surface PrisMCP.
 export const INSTRUCTIONS =
@@ -33,6 +34,18 @@ export function createServer() {
     'list_courses',
     { description: 'List active (non-archived) Prism courses, to resolve which class to grade.' },
     async () => ({ content: [{ type: 'text', text: JSON.stringify(listCourses(getDb())) }] })
+  );
+
+  server.registerTool(
+    'list_assignments',
+    {
+      description:
+        "List a course's assignments (with aligned-topic + latest-submission hints) to resolve which assignment to grade.",
+      inputSchema: { course_id: z.union([z.number(), z.string()]).describe('Local Prism course id') },
+    },
+    async ({ course_id }) => ({
+      content: [{ type: 'text', text: JSON.stringify(listAssignments(getDb(), { course_id })) }],
+    })
   );
 
   return server;

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { getDb } from '../server/db/index.js';
+import { getAssessmentContext } from '../server/services/assessmentContext.js';
 import { listCourses, listAssignments } from './handlers.js';
 
 // <2KB tool-search hint (spec §3.4) so a client knows when to surface PrisMCP.
@@ -45,6 +46,23 @@ export function createServer() {
     },
     async ({ course_id }) => ({
       content: [{ type: 'text', text: JSON.stringify(listAssignments(getDb(), { course_id })) }],
+    })
+  );
+
+  server.registerTool(
+    'get_assignment_context',
+    {
+      description:
+        'Load an assignment\'s roster, aligned measurement topics (rubric skeleton), current finals/comments/display-status, and any existing AI suggestions, to grade against.',
+      inputSchema: {
+        course_id: z.union([z.number(), z.string()]).describe('Local Prism course id'),
+        assignment_id: z.union([z.number(), z.string()]).describe('Schoology or local assignment id'),
+      },
+    },
+    async ({ course_id, assignment_id }) => ({
+      content: [
+        { type: 'text', text: JSON.stringify(getAssessmentContext(getDb(), { courseId: course_id, assignmentId: assignment_id })) },
+      ],
     })
   );
 

--- a/mcp/server.test.js
+++ b/mcp/server.test.js
@@ -20,8 +20,9 @@ async function connect() {
 
 beforeEach(() => {
   getDb().exec(
-    'DELETE FROM mastery_alignments; DELETE FROM grades; DELETE FROM assignments; ' +
-    'DELETE FROM students; DELETE FROM courses;'
+    'DELETE FROM feedback; DELETE FROM mastery_alignments; DELETE FROM mastery_scores; ' +
+    'DELETE FROM measurement_topics; DELETE FROM reporting_categories; DELETE FROM grades; ' +
+    'DELETE FROM enrolments; DELETE FROM assignments; DELETE FROM students; DELETE FROM courses;'
   );
 });
 
@@ -46,6 +47,24 @@ describe('PrisMCP server', () => {
     const res = await client.callTool({ name: 'list_assignments', arguments: { course_id: c1 } });
     const data = JSON.parse(res.content[0].text);
     expect(data.map((a) => a.title)).toEqual(['App Project']);
+  });
+
+  test('exposes get_assignment_context accepting a Schoology assignment id', async () => {
+    const db = getDb();
+    const courseId = db.prepare(`INSERT INTO courses (schoology_section_id, course_name) VALUES ('s1', 'AIML')`).run().lastInsertRowid;
+    db.prepare(`INSERT INTO reporting_categories (id, course_id, external_id, title) VALUES ('cat-1', ?, 'ART.5', 'Creating')`).run(courseId);
+    db.prepare(`INSERT INTO measurement_topics (id, category_id, course_id, external_id, title) VALUES ('topic-1', 'cat-1', ?, 'ART.5.1', 'Generates media')`).run(courseId);
+    db.prepare(`INSERT INTO assignments (course_id, schoology_assignment_id, title) VALUES (?, 'sa-1', 'Project')`).run(courseId);
+    db.prepare(`INSERT INTO mastery_alignments (assignment_schoology_id, topic_id, course_id) VALUES ('sa-1', 'topic-1', ?)`).run(courseId);
+    const studentId = db.prepare(`INSERT INTO students (schoology_uid, first_name, last_name) VALUES ('uid-1', 'Ada', 'Lovelace')`).run().lastInsertRowid;
+    db.prepare(`INSERT INTO enrolments (student_id, course_id, schoology_enrolment_id) VALUES (?, ?, 'enr-1')`).run(studentId, courseId);
+
+    const client = await connect();
+    const res = await client.callTool({ name: 'get_assignment_context', arguments: { course_id: courseId, assignment_id: 'sa-1' } });
+    const ctx = JSON.parse(res.content[0].text);
+    expect(ctx.assignment.schoology_assignment_id).toBe('sa-1');
+    expect(ctx.topics.map((t) => t.external_id)).toEqual(['ART.5.1']);
+    expect(ctx.students.map((s) => s.schoology_uid)).toEqual(['uid-1']);
   });
 
   test('advertises the tool-search instructions to the client', async () => {

--- a/mcp/server.test.js
+++ b/mcp/server.test.js
@@ -19,7 +19,10 @@ async function connect() {
 }
 
 beforeEach(() => {
-  getDb().exec('DELETE FROM courses;');
+  getDb().exec(
+    'DELETE FROM mastery_alignments; DELETE FROM grades; DELETE FROM assignments; ' +
+    'DELETE FROM students; DELETE FROM courses;'
+  );
 });
 
 describe('PrisMCP server', () => {
@@ -31,6 +34,18 @@ describe('PrisMCP server', () => {
     const res = await client.callTool({ name: 'list_courses', arguments: {} });
     const data = JSON.parse(res.content[0].text);
     expect(data.map((c) => c.course_name)).toEqual(['Robotics']);
+  });
+
+  test('exposes list_assignments scoped to the requested course', async () => {
+    const db = getDb();
+    const c1 = db.prepare(`INSERT INTO courses (schoology_section_id, course_name) VALUES ('s1', 'MAD')`).run().lastInsertRowid;
+    const c2 = db.prepare(`INSERT INTO courses (schoology_section_id, course_name) VALUES ('s2', 'ROB')`).run().lastInsertRowid;
+    db.prepare(`INSERT INTO assignments (course_id, schoology_assignment_id, title) VALUES (?, 'a1', 'App Project')`).run(c1);
+    db.prepare(`INSERT INTO assignments (course_id, schoology_assignment_id, title) VALUES (?, 'a2', 'Other Course Task')`).run(c2);
+    const client = await connect();
+    const res = await client.callTool({ name: 'list_assignments', arguments: { course_id: c1 } });
+    const data = JSON.parse(res.content[0].text);
+    expect(data.map((a) => a.title)).toEqual(['App Project']);
   });
 
   test('advertises the tool-search instructions to the client', async () => {

--- a/server/routes/feedback.js
+++ b/server/routes/feedback.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import multer from 'multer';
 import { getDb } from '../db/index.js';
 import { processInbox, importSingleFeedback } from '../services/inbox.js';
+import { getExistingSuggestions } from '../services/assessmentContext.js';
 
 const router = Router();
 const upload = multer({ storage: multer.memoryStorage() });
@@ -25,16 +26,7 @@ router.get('/for-assignment/:assignmentId', (req, res) => {
     'SELECT id FROM assignments WHERE schoology_assignment_id = ?'
   ).get(req.params.assignmentId);
   if (!assignment) return res.json({});
-  const rows = db.prepare(`
-    SELECT * FROM feedback
-    WHERE assignment_id = ? AND status IN ('draft', 'teacher_modified')
-  `).all(assignment.id);
-  const byStudent = {};
-  for (const row of rows) {
-    row.feedback_parsed = JSON.parse(row.feedback_json || '{}');
-    byStudent[row.student_id] = row;
-  }
-  res.json(byStudent);
+  res.json(getExistingSuggestions(db, assignment.id));
 });
 
 // GET /api/feedback/analysis/:assignmentId — the assessment_analysis record for

--- a/server/routes/mastery.js
+++ b/server/routes/mastery.js
@@ -3,6 +3,7 @@ import { getDb } from '../db/index.js';
 import { hasMasterySession, syncMasteryForCourse, syncMasteryForAssignment, writeMasteryScores, writeMasteryScoresBatch, writeMasteryOverride, getMasteryForCourse, getRubricScoresForStudent, interactiveLogin } from '../services/masterySync.js';
 import { pushGradeComments, getSectionGrades } from '../services/schoology.js';
 import { isResubmitted } from '../lib/resubmission.js';
+import { getAlignedTopics, getRoster, getScoreMap, getGradeMetaRows } from '../services/assessmentContext.js';
 
 const router = Router();
 const syncsInProgress = new Set();
@@ -372,66 +373,19 @@ router.get('/:courseId/assignment/:assignmentId', (req, res) => {
   const { courseId, assignmentId } = req.params;
   const db = getDb();
 
-  // Aligned topics for THIS assignment, sourced from the authoritative
-  // mastery_alignments table. Falls back to topics that have any score for
-  // this assignment if alignments haven't been synced yet — so a freshly
-  // aligned assignment with no grades still renders its rubric.
-  let topics = db.prepare(`
-    SELECT DISTINCT mt.*, rc.title AS category_title, rc.external_id AS category_external_id
-    FROM measurement_topics mt
-    JOIN reporting_categories rc ON rc.id = mt.category_id
-    WHERE mt.id IN (
-      SELECT ma.topic_id FROM mastery_alignments ma
-      WHERE ma.assignment_schoology_id = ? AND ma.course_id = ?
-    )
-    ORDER BY rc.external_id, mt.external_id
-  `).all(assignmentId, courseId);
-
-  if (topics.length === 0) {
-    topics = db.prepare(`
-      SELECT DISTINCT mt.*, rc.title AS category_title, rc.external_id AS category_external_id
-      FROM measurement_topics mt
-      JOIN reporting_categories rc ON rc.id = mt.category_id
-      WHERE mt.id IN (
-        SELECT DISTINCT ms.topic_id FROM mastery_scores ms
-        WHERE ms.assignment_schoology_id = ?
-      )
-      ORDER BY rc.external_id, mt.external_id
-    `).all(assignmentId);
-  }
+  // Aligned topics, roster (honoring #54 targeting), scores, and grade-meta are
+  // shared with PrisMCP via server/services/assessmentContext.js. The topics
+  // query falls back to scored topics when alignments haven't synced yet.
+  const topics = getAlignedTopics(db, courseId, assignmentId);
 
   const assignmentRow = db.prepare(`
     SELECT * FROM assignments WHERE schoology_assignment_id = ? AND course_id = ?
   `).get(assignmentId, courseId);
 
-  // Hide students an individually-targeted assignment isn't assigned to —
-  // matches the student-page rule (#54). assignmentRow is undefined for an
-  // unknown assignment id; treat that as "no targeting" so the roster still
-  // renders.
-  const targeted = assignmentRow && assignmentRow.num_assignees && assignmentRow.num_assignees > 0;
-  const students = db.prepare(targeted ? `
-    SELECT s.id, s.schoology_uid, s.first_name, s.last_name, s.preferred_name, s.preferred_name_teacher,
-           s.picture_url,
-           e.schoology_enrolment_id AS enrollment_id
-    FROM students s
-    JOIN enrolments e ON e.student_id = s.id
-    JOIN assignment_assignees aa ON aa.schoology_uid = s.schoology_uid AND aa.assignment_id = ?
-    WHERE e.course_id = ?
-    ORDER BY s.last_name, s.first_name
-  ` : `
-    SELECT s.id, s.schoology_uid, s.first_name, s.last_name, s.preferred_name, s.preferred_name_teacher,
-           s.picture_url,
-           e.schoology_enrolment_id AS enrollment_id
-    FROM students s
-    JOIN enrolments e ON e.student_id = s.id
-    WHERE e.course_id = ?
-    ORDER BY s.last_name, s.first_name
-  `).all(...(targeted ? [assignmentRow.id, courseId] : [courseId]));
-
-  const scores = topics.length > 0 ? db.prepare(`
-    SELECT * FROM mastery_scores WHERE assignment_schoology_id = ?
-    AND topic_id IN (${topics.map(() => '?').join(',')})
-  `).all(assignmentId, ...topics.map(t => t.id)) : [];
+  // getRoster hides students an individually-targeted assignment isn't assigned
+  // to (#54); an undefined assignmentRow (unknown id) is treated as open-to-all.
+  const students = getRoster(db, courseId, assignmentRow);
+  const scoreMap = getScoreMap(db, assignmentId, topics.map(t => t.id));
 
   // Grade comments + exception + comment_status from the regular grades table.
   // Exception (1=Excused, 2=Incomplete, 3=Missing, 4=Late) deletes any
@@ -440,14 +394,7 @@ router.get('/:courseId/assignment/:assignmentId', (req, res) => {
   // comment_status drives the Display-to-student toggle (#34): integer 1 = visible,
   // null/missing = hidden. has_grade_row distinguishes "synced and got null"
   // from "never synced" so the client can arm auto-flip only for virgin rows.
-  const gradeRows = db.prepare(`
-    SELECT s.schoology_uid, g.score, g.submitted_at, g.latest_revision_at, g.grade_comment, g.exception, g.comment_status
-    FROM grades g
-    JOIN students s ON s.id = g.student_id
-    JOIN assignments a ON a.id = g.assignment_id
-    WHERE a.schoology_assignment_id = ?
-  `).all(assignmentId);
-
+  const gradeRows = getGradeMetaRows(db, assignmentId);
   const commentMap = {};
   const exceptionMap = {};
   const commentStatusMap = {};
@@ -459,12 +406,6 @@ router.get('/:courseId/assignment/:assignmentId', (req, res) => {
     commentStatusMap[c.schoology_uid] = c.comment_status ?? null;
     hasGradeRowMap[c.schoology_uid] = true;
     resubmittedMap[c.schoology_uid] = isResubmitted(c);
-  }
-
-  const scoreMap = {};
-  for (const sc of scores) {
-    if (!scoreMap[sc.student_uid]) scoreMap[sc.student_uid] = {};
-    scoreMap[sc.student_uid][sc.topic_id] = { points: sc.points, grade: sc.grade };
   }
 
   // Submission-scoped 'review needed' flags for this assignment (#20).

--- a/server/services/assessmentContext.js
+++ b/server/services/assessmentContext.js
@@ -1,0 +1,170 @@
+// Shared assessment-context reads. The whole-class rubric view in
+// server/routes/mastery.js and the existing-suggestions read in
+// server/routes/feedback.js were both inlined; they are extracted here so the
+// Express routes and the PrisMCP server compose the same queries (spec §6).
+//
+// Each helper takes an open better-sqlite3 db. getAssessmentContext composes
+// them into the PrisMCP get_assignment_context shape (spec §3.1).
+
+import { resolveAssignmentId } from './idResolvers.js';
+
+// Aligned measurement topics for an assignment (the rubric skeleton), from the
+// authoritative mastery_alignments table; falls back to topics that have any
+// score for the assignment when alignments haven't synced yet.
+export function getAlignedTopics(db, courseId, assignmentSchoologyId) {
+  let topics = db.prepare(`
+    SELECT DISTINCT mt.*, rc.title AS category_title, rc.external_id AS category_external_id
+    FROM measurement_topics mt
+    JOIN reporting_categories rc ON rc.id = mt.category_id
+    WHERE mt.id IN (
+      SELECT ma.topic_id FROM mastery_alignments ma
+      WHERE ma.assignment_schoology_id = ? AND ma.course_id = ?
+    )
+    ORDER BY rc.external_id, mt.external_id
+  `).all(assignmentSchoologyId, courseId);
+
+  if (topics.length === 0) {
+    topics = db.prepare(`
+      SELECT DISTINCT mt.*, rc.title AS category_title, rc.external_id AS category_external_id
+      FROM measurement_topics mt
+      JOIN reporting_categories rc ON rc.id = mt.category_id
+      WHERE mt.id IN (
+        SELECT DISTINCT ms.topic_id FROM mastery_scores ms
+        WHERE ms.assignment_schoology_id = ?
+      )
+      ORDER BY rc.external_id, mt.external_id
+    `).all(assignmentSchoologyId);
+  }
+  return topics;
+}
+
+// Roster for an assignment, honoring #54 individual targeting: an assignment
+// with num_assignees > 0 lists only its assignees, otherwise the whole section.
+// assignmentRow may be undefined (unknown assignment) → treated as open-to-all.
+export function getRoster(db, courseId, assignmentRow) {
+  const targeted = assignmentRow && assignmentRow.num_assignees && assignmentRow.num_assignees > 0;
+  return db.prepare(targeted ? `
+    SELECT s.id, s.schoology_uid, s.first_name, s.last_name, s.preferred_name, s.preferred_name_teacher,
+           s.picture_url, e.schoology_enrolment_id AS enrollment_id
+    FROM students s
+    JOIN enrolments e ON e.student_id = s.id
+    JOIN assignment_assignees aa ON aa.schoology_uid = s.schoology_uid AND aa.assignment_id = ?
+    WHERE e.course_id = ?
+    ORDER BY s.last_name, s.first_name
+  ` : `
+    SELECT s.id, s.schoology_uid, s.first_name, s.last_name, s.preferred_name, s.preferred_name_teacher,
+           s.picture_url, e.schoology_enrolment_id AS enrollment_id
+    FROM students s
+    JOIN enrolments e ON e.student_id = s.id
+    WHERE e.course_id = ?
+    ORDER BY s.last_name, s.first_name
+  `).all(...(targeted ? [assignmentRow.id, courseId] : [courseId]));
+}
+
+// { schoology_uid: { topic_id: { points, grade } } } for the given topic ids.
+export function getScoreMap(db, assignmentSchoologyId, topicIds) {
+  const scores = topicIds.length > 0 ? db.prepare(`
+    SELECT * FROM mastery_scores WHERE assignment_schoology_id = ?
+    AND topic_id IN (${topicIds.map(() => '?').join(',')})
+  `).all(assignmentSchoologyId, ...topicIds) : [];
+  const scoreMap = {};
+  for (const sc of scores) {
+    if (!scoreMap[sc.student_uid]) scoreMap[sc.student_uid] = {};
+    scoreMap[sc.student_uid][sc.topic_id] = { points: sc.points, grade: sc.grade };
+  }
+  return scoreMap;
+}
+
+// Raw grade-meta rows (comment / exception / comment_status / submission times)
+// joined to the schoology_uid, for an assignment. Consumers build their own maps.
+export function getGradeMetaRows(db, assignmentSchoologyId) {
+  return db.prepare(`
+    SELECT s.schoology_uid, g.score, g.submitted_at, g.latest_revision_at,
+           g.grade_comment, g.exception, g.comment_status
+    FROM grades g
+    JOIN students s ON s.id = g.student_id
+    JOIN assignments a ON a.id = g.assignment_id
+    WHERE a.schoology_assignment_id = ?
+  `).all(assignmentSchoologyId);
+}
+
+// Existing AI suggestions (draft / teacher_modified) for an assignment (local
+// id), keyed by student_id, each with parsed feedback_json. Mirrors the
+// feedback for-assignment read; approved rows are excluded so they stop
+// re-surfacing as suggestions.
+export function getExistingSuggestions(db, assignmentLocalId) {
+  const rows = db.prepare(`
+    SELECT * FROM feedback
+    WHERE assignment_id = ? AND status IN ('draft', 'teacher_modified')
+  `).all(assignmentLocalId);
+  const byStudent = {};
+  for (const row of rows) {
+    row.feedback_parsed = JSON.parse(row.feedback_json || '{}');
+    byStudent[row.student_id] = row;
+  }
+  return byStudent;
+}
+
+// Compose the PrisMCP get_assignment_context shape (spec §3.1): assignment
+// meta + aligned topics + roster with current finals/comments/display-status +
+// any existing AI suggestion. assignmentId accepts a Schoology or local id.
+// Returns null for an unknown assignment.
+export function getAssessmentContext(db, { assignmentId }) {
+  const localId = resolveAssignmentId(db, assignmentId);
+  const assignmentRow = localId ? db.prepare('SELECT * FROM assignments WHERE id = ?').get(localId) : null;
+  if (!assignmentRow) return null;
+
+  const courseId = assignmentRow.course_id;
+  const schoolyId = assignmentRow.schoology_assignment_id;
+
+  const topics = getAlignedTopics(db, courseId, schoolyId);
+  const roster = getRoster(db, courseId, assignmentRow);
+  const scoreMap = getScoreMap(db, schoolyId, topics.map((t) => t.id));
+  const suggestions = getExistingSuggestions(db, assignmentRow.id);
+
+  const metaByUid = {};
+  for (const g of getGradeMetaRows(db, schoolyId)) metaByUid[g.schoology_uid] = g;
+
+  const students = roster.map((st) => {
+    const meta = metaByUid[st.schoology_uid] || {};
+    const sug = suggestions[st.id];
+    return {
+      id: st.id,
+      schoology_uid: st.schoology_uid,
+      enrollment_id: st.enrollment_id,
+      first_name: st.first_name,
+      last_name: st.last_name,
+      preferred_name: st.preferred_name,
+      current_scores: scoreMap[st.schoology_uid] || {},
+      grade_comment: meta.grade_comment || '',
+      display_to_student: (meta.comment_status ?? null) === 1,
+      exception: meta.exception ?? 0,
+      existing_suggestion: sug
+        ? {
+            status: sug.status,
+            narrative_feedback: sug.feedback_parsed.narrative_feedback ?? '',
+            rubric_scores: sug.feedback_parsed.rubric_scores ?? {},
+            reviewer_flags: sug.feedback_parsed.reviewer_flags ?? null,
+          }
+        : null,
+    };
+  });
+
+  return {
+    assignment: {
+      id: assignmentRow.id,
+      schoology_assignment_id: assignmentRow.schoology_assignment_id,
+      title: assignmentRow.title,
+      max_points: assignmentRow.max_points,
+      grading_scale: assignmentRow.grading_scale_id ?? null,
+    },
+    topics: topics.map((t) => ({
+      id: t.id,
+      external_id: t.external_id,
+      title: t.title,
+      category_title: t.category_title,
+      category_external_id: t.category_external_id,
+    })),
+    students,
+  };
+}

--- a/server/services/assessmentContext.test.js
+++ b/server/services/assessmentContext.test.js
@@ -1,0 +1,106 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+
+vi.hoisted(() => { process.env.DB_PATH = ':memory:'; });
+
+import { getDb } from '../db/index.js';
+import { getAssessmentContext } from './assessmentContext.js';
+
+// Seed one fully-populated assignment context: a course, a reporting category +
+// aligned measurement topic, an assignment, a roster of one enrolled student
+// with a synced final score + grade comment, and an existing AI draft suggestion.
+function seedContext(db) {
+  const courseId = db.prepare(
+    `INSERT INTO courses (schoology_section_id, course_name) VALUES ('sec-1', 'AIML')`
+  ).run().lastInsertRowid;
+  db.prepare(`INSERT INTO reporting_categories (id, course_id, external_id, title) VALUES ('cat-1', ?, 'ART.5', 'Creating')`).run(courseId);
+  db.prepare(`INSERT INTO measurement_topics (id, category_id, course_id, external_id, title) VALUES ('topic-1', 'cat-1', ?, 'ART.5.1', 'Generates media')`).run(courseId);
+  const assignmentId = db.prepare(
+    `INSERT INTO assignments (course_id, schoology_assignment_id, title, max_points, grading_scale_id) VALUES (?, 'sa-1', 'Project', 100, 'gs-1')`
+  ).run(courseId).lastInsertRowid;
+  db.prepare(`INSERT INTO mastery_alignments (assignment_schoology_id, topic_id, course_id) VALUES ('sa-1', 'topic-1', ?)`).run(courseId);
+  const studentId = db.prepare(
+    `INSERT INTO students (schoology_uid, first_name, last_name, preferred_name) VALUES ('uid-1', 'Ada', 'Lovelace', 'Ada')`
+  ).run().lastInsertRowid;
+  db.prepare(`INSERT INTO enrolments (student_id, course_id, schoology_enrolment_id) VALUES (?, ?, 'enr-1')`).run(studentId, courseId);
+  db.prepare(`INSERT INTO mastery_scores (student_uid, assignment_schoology_id, topic_id, points, grade) VALUES ('uid-1', 'sa-1', 'topic-1', 75, 'EX')`).run();
+  db.prepare(`INSERT INTO grades (student_id, assignment_id, grade_comment, exception, comment_status) VALUES (?, ?, 'Nice work', 0, 1)`).run(studentId, assignmentId);
+  db.prepare(`INSERT INTO feedback (student_id, assignment_id, status, feedback_json) VALUES (?, ?, 'draft', ?)`).run(
+    studentId, assignmentId,
+    JSON.stringify({ narrative_feedback: 'Strong concept', rubric_scores: { 'ART.5.1': 'ED' }, reviewer_flags: 'check sources' })
+  );
+  return { courseId, assignmentId, studentId };
+}
+
+beforeEach(() => {
+  getDb().exec(
+    'DELETE FROM feedback; DELETE FROM mastery_alignments; DELETE FROM mastery_scores; ' +
+    'DELETE FROM grades; DELETE FROM measurement_topics; DELETE FROM reporting_categories; ' +
+    'DELETE FROM enrolments; DELETE FROM assignments; DELETE FROM students; DELETE FROM courses;'
+  );
+});
+
+describe('getAssessmentContext', () => {
+  test('composes assignment + aligned topics + roster + finals/comments + existing suggestion', () => {
+    const db = getDb();
+    const { courseId } = seedContext(db);
+
+    const ctx = getAssessmentContext(db, { courseId, assignmentId: 'sa-1' });
+
+    expect(ctx.assignment).toMatchObject({ schoology_assignment_id: 'sa-1', title: 'Project', max_points: 100 });
+    expect(ctx.topics).toEqual([
+      { id: 'topic-1', external_id: 'ART.5.1', title: 'Generates media', category_title: 'Creating', category_external_id: 'ART.5' },
+    ]);
+    expect(ctx.students).toHaveLength(1);
+    const s = ctx.students[0];
+    expect(s).toMatchObject({
+      schoology_uid: 'uid-1',
+      enrollment_id: 'enr-1',
+      first_name: 'Ada',
+      preferred_name: 'Ada',
+      grade_comment: 'Nice work',
+      display_to_student: true,
+      exception: 0,
+    });
+    expect(s.current_scores).toEqual({ 'topic-1': { grade: 'EX', points: 75 } });
+    expect(s.existing_suggestion).toMatchObject({
+      status: 'draft',
+      narrative_feedback: 'Strong concept',
+      rubric_scores: { 'ART.5.1': 'ED' },
+      reviewer_flags: 'check sources',
+    });
+  });
+
+  test('accepts a local assignment id as well as the Schoology id', () => {
+    const db = getDb();
+    const { assignmentId } = seedContext(db);
+    expect(getAssessmentContext(db, { assignmentId }).assignment.schoology_assignment_id).toBe('sa-1');
+  });
+
+  test('existing_suggestion is null when no draft/teacher_modified row exists', () => {
+    const db = getDb();
+    seedContext(db);
+    db.prepare('DELETE FROM feedback').run();
+    const ctx = getAssessmentContext(db, { assignmentId: 'sa-1' });
+    expect(ctx.students[0].existing_suggestion).toBeNull();
+  });
+
+  test('excludes approved feedback from existing_suggestion', () => {
+    const db = getDb();
+    const { studentId } = seedContext(db);
+    db.prepare(`UPDATE feedback SET status = 'approved' WHERE student_id = ?`).run(studentId);
+    const ctx = getAssessmentContext(db, { assignmentId: 'sa-1' });
+    expect(ctx.students[0].existing_suggestion).toBeNull();
+  });
+
+  test('display_to_student is false when comment_status is not 1', () => {
+    const db = getDb();
+    const { studentId } = seedContext(db);
+    db.prepare('UPDATE grades SET comment_status = NULL WHERE student_id = ?').run(studentId);
+    const ctx = getAssessmentContext(db, { assignmentId: 'sa-1' });
+    expect(ctx.students[0].display_to_student).toBe(false);
+  });
+
+  test('returns null for an unknown assignment', () => {
+    expect(getAssessmentContext(getDb(), { assignmentId: 'no-such' })).toBeNull();
+  });
+});

--- a/server/services/idResolvers.js
+++ b/server/services/idResolvers.js
@@ -1,0 +1,24 @@
+// Shared id resolvers. A caller may reference a student or assignment by its
+// local Prism id OR by a Schoology id (and, for students, a PowerSchool id);
+// these resolve any of those to the local row id, or null. Extracted from
+// inbox.js so the inbox importer and the PrisMCP server share one resolution
+// rule (spec §6). Each returns the local integer id, or null when unresolved.
+
+export function resolveStudentId(db, rawId) {
+  // Try as internal id first, then schoology_uid, then powerschool_id.
+  let row = db.prepare('SELECT id FROM students WHERE id = ?').get(rawId);
+  if (row) return row.id;
+  row = db.prepare('SELECT id FROM students WHERE schoology_uid = ?').get(String(rawId));
+  if (row) return row.id;
+  row = db.prepare('SELECT id FROM students WHERE powerschool_id = ?').get(String(rawId));
+  if (row) return row.id;
+  return null;
+}
+
+export function resolveAssignmentId(db, rawId) {
+  let row = db.prepare('SELECT id FROM assignments WHERE id = ?').get(rawId);
+  if (row) return row.id;
+  row = db.prepare('SELECT id FROM assignments WHERE schoology_assignment_id = ?').get(String(rawId));
+  if (row) return row.id;
+  return null;
+}

--- a/server/services/inbox.js
+++ b/server/services/inbox.js
@@ -3,6 +3,7 @@ import { join, basename } from 'path';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import { getDb } from '../db/index.js';
+import { resolveStudentId, resolveAssignmentId } from './idResolvers.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const INBOX_DIR = process.env.INBOX_DIR || join(__dirname, '..', '..', 'inbox');
@@ -31,25 +32,6 @@ function validate(data, filename) {
     errors.push('suggestions must be an array');
   }
   return errors;
-}
-
-function resolveStudentId(db, rawId) {
-  // Try as internal ID first, then schoology_uid, then powerschool_id
-  let row = db.prepare('SELECT id FROM students WHERE id = ?').get(rawId);
-  if (row) return row.id;
-  row = db.prepare('SELECT id FROM students WHERE schoology_uid = ?').get(String(rawId));
-  if (row) return row.id;
-  row = db.prepare('SELECT id FROM students WHERE powerschool_id = ?').get(String(rawId));
-  if (row) return row.id;
-  return null;
-}
-
-function resolveAssignmentId(db, rawId) {
-  let row = db.prepare('SELECT id FROM assignments WHERE id = ?').get(rawId);
-  if (row) return row.id;
-  row = db.prepare('SELECT id FROM assignments WHERE schoology_assignment_id = ?').get(String(rawId));
-  if (row) return row.id;
-  return null;
 }
 
 function importFeedbackRecord(db, data, filename) {


### PR DESCRIPTION
## Slice 3 of #84 (PrisMCP server) — stacked on #94

The primary read tool, `get_assignment_context`, plus the two shared-service extractions it needs (spec §6).

### Tool
`get_assignment_context(course_id, assignment_id)` → the §3.1 shape: assignment meta + aligned measurement topics (rubric skeleton) + roster with `current_scores` / `grade_comment` / `display_to_student` / `exception` + `existing_suggestion` (draft/teacher_modified, else null). Accepts a **Schoology or local** assignment id.

### Extractions (behaviour-preserving)
- `server/services/idResolvers.js` — `resolveStudentId`/`resolveAssignmentId` moved out of `inbox.js` (inbox imports them).
- `server/services/assessmentContext.js` — `getAlignedTopics`, `getRoster`, `getScoreMap`, `getGradeMetaRows`, `getExistingSuggestions`, and the composed `getAssessmentContext`. The mastery whole-class route and the feedback for-assignment route are **rewired onto these helpers**; their existing tests stay green.

### Verification
- `npx vitest run` → **173 passed** (existing `mastery.test.js` / `feedback.test.js` unchanged-green confirms the refactor preserved behaviour; 6 new `assessmentContext` unit tests + 1 MCP integration test).

> **Stacked PR:** base is `feat/prismcp-slice-2-list-assignments` (#94). Merge #93 → #94 → this, in order.

Closes #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)