### PR TITLE
feat(sync): opt-in recent-only submission-status window (#55)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ npm run test:api   # Schoology API smoke test
 - **Page wrapper:** Add `className="fade-in"` to the top-level div of each page for entry animation.
 - **Sidebar width:** 240px (set in CSS), content margin-left matches.
 - **Adding new themes:** Add a `[data-theme="name"]` block in `app.css` with all CSS variables, add the theme key to `themes` in `useTheme.jsx`. No component changes needed.
+- **Design language & decisions:** `docs/design-language.md` is the running log of Prism's visual patterns and the rationale behind UI decisions (tracked by #80). Reuse the shared primitives documented there — e.g. `.help-dot` + `.help-pop` (the instant help-"?" popover) and `.number-stepper` — instead of re-inlining them. **Whenever you make a notable UI/visual decision, append it to that doc** so the language can later be unified.
 
 ## Key References
 

--- a/client/src/app.css
+++ b/client/src/app.css
@@ -799,6 +799,29 @@ button.ghost.accent:hover { background: var(--accent-light); }
 
 .sync-disclaimer, .sync-login-prompt { font-size: 0.8rem; margin: 0.6rem 0; }
 .sync-login-prompt button { margin-top: 0.5rem; }
+.sync-help {
+  margin-left: 0.15rem;
+  font-size: 0.8em;
+  cursor: help;
+  color: var(--text-muted);
+}
+.sync-recent-days {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.9em;
+  padding-left: 1.6rem;
+  margin-top: 0.3rem;
+}
+.number-stepper {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+.number-stepper input[type="number"] {
+  width: 3.5rem;
+  text-align: center;
+}
 
 .sync-group { margin: 0.25rem 0 0.25rem 0.5rem; }
 .sync-group-head { display: flex; align-items: center; gap: 0.4rem; }

--- a/client/src/app.css
+++ b/client/src/app.css
@@ -799,29 +799,107 @@ button.ghost.accent:hover { background: var(--accent-light); }
 
 .sync-disclaimer, .sync-login-prompt { font-size: 0.8rem; margin: 0.6rem 0; }
 .sync-login-prompt button { margin-top: 0.5rem; }
-.sync-help {
-  margin-left: 0.15rem;
-  font-size: 0.8em;
+.sync-toggle-row { display: flex; align-items: center; gap: 0.4rem; }
+
+/* Reusable help affordance: a stand-out circular "?" with an INSTANT popover on
+   hover/focus (mirrors the gradebook HelpDot/popover). See docs/design-language.md. */
+.help-dot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--accent-subtle);
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  font-size: 0.68rem;
+  font-weight: 700;
+  line-height: 1;
   cursor: help;
-  color: var(--text-muted);
+  user-select: none;
+  vertical-align: middle;
 }
+.help-dot:hover,
+.help-dot:focus-visible {
+  background: var(--accent);
+  color: white;
+  outline: none;
+}
+.help-pop {
+  position: fixed;
+  transform: translateX(-50%);
+  width: max-content;
+  max-width: 260px;
+  z-index: 1300;
+  background: var(--card-bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.18);
+  padding: 0.55rem 0.7rem;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  pointer-events: none;
+}
+
 .sync-recent-days {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.45rem;
   font-size: 0.9em;
-  padding-left: 1.6rem;
-  margin-top: 0.3rem;
+  padding-left: 1.65rem;
+  margin-top: 0.1rem;
+  color: var(--text-muted);
 }
+
+/* Number stepper: prominent −/+ controls flanking a number that reads as plain
+   text until focused. Native spinners hidden. See docs/design-language.md. */
 .number-stepper {
   display: inline-flex;
+  align-items: stretch;
+  height: 1.85rem;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  overflow: hidden;
+  background: var(--card-bg);
+}
+.number-stepper__btn {
+  border: none;
+  background: var(--bg-subtle);
+  color: var(--accent);
+  font-size: 1.05rem;
+  font-weight: 700;
+  line-height: 1;
+  width: 1.9rem;
+  padding: 0;
+  cursor: pointer;
+  display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  justify-content: center;
+  transition: background 0.12s ease, color 0.12s ease;
 }
+.number-stepper__btn:hover:not(:disabled) { background: var(--accent); color: white; }
+.number-stepper__btn:disabled { opacity: 0.4; cursor: default; }
 .number-stepper input[type="number"] {
-  width: 3.5rem;
+  width: 2.7rem;
   text-align: center;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 0.92rem;
+  font-weight: 600;
+  padding: 0;
+  outline: none;
+  -moz-appearance: textfield;
+  appearance: textfield;
 }
+.number-stepper input[type="number"]::-webkit-outer-spin-button,
+.number-stepper input[type="number"]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.number-stepper input[type="number"]:focus { background: var(--bg-subtle); }
 
 .sync-group { margin: 0.25rem 0 0.25rem 0.5rem; }
 .sync-group-head { display: flex; align-items: center; gap: 0.4rem; }

--- a/client/src/components/NumberStepper.jsx
+++ b/client/src/components/NumberStepper.jsx
@@ -1,0 +1,23 @@
+// A controlled [−] N [+] integer stepper. Emits clamped integer values via
+// onChange. Non-numeric typed input is ignored (the field stays controlled).
+export default function NumberStepper({ value, onChange, min = 1, max = 365, ...rest }) {
+  const clamp = (n) => Math.min(max, Math.max(min, Math.floor(n)));
+  const emit = (n) => { if (Number.isFinite(n)) onChange(clamp(n)); };
+  return (
+    <span className="number-stepper">
+      <button
+        type="button" className="ghost" aria-label="Decrease"
+        onClick={() => emit(value - 1)} disabled={value <= min}
+      >−</button>
+      <input
+        type="number" inputMode="numeric" min={min} max={max} value={value}
+        onChange={(e) => { const n = parseInt(e.target.value, 10); if (!Number.isNaN(n)) emit(n); }}
+        {...rest}
+      />
+      <button
+        type="button" className="ghost" aria-label="Increase"
+        onClick={() => emit(value + 1)} disabled={value >= max}
+      >+</button>
+    </span>
+  );
+}

--- a/client/src/components/NumberStepper.jsx
+++ b/client/src/components/NumberStepper.jsx
@@ -6,7 +6,7 @@ export default function NumberStepper({ value, onChange, min = 1, max = 365, ...
   return (
     <span className="number-stepper">
       <button
-        type="button" className="ghost" aria-label="Decrease"
+        type="button" className="number-stepper__btn" aria-label="Decrease"
         onClick={() => emit(value - 1)} disabled={value <= min}
       >−</button>
       <input
@@ -15,7 +15,7 @@ export default function NumberStepper({ value, onChange, min = 1, max = 365, ...
         {...rest}
       />
       <button
-        type="button" className="ghost" aria-label="Increase"
+        type="button" className="number-stepper__btn" aria-label="Increase"
         onClick={() => emit(value + 1)} disabled={value >= max}
       >+</button>
     </span>

--- a/client/src/components/NumberStepper.test.jsx
+++ b/client/src/components/NumberStepper.test.jsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import NumberStepper from './NumberStepper.jsx';
+
+function setup(value = 30) {
+  const onChange = vi.fn();
+  render(<NumberStepper value={value} onChange={onChange} min={1} max={365} aria-label="Day window" />);
+  return { onChange };
+}
+
+describe('NumberStepper', () => {
+  it('increments and decrements by one', () => {
+    const { onChange } = setup(30);
+    fireEvent.click(screen.getByRole('button', { name: /increase/i }));
+    expect(onChange).toHaveBeenCalledWith(31);
+    fireEvent.click(screen.getByRole('button', { name: /decrease/i }));
+    expect(onChange).toHaveBeenCalledWith(29);
+  });
+
+  it('disables the buttons at the bounds', () => {
+    render(<NumberStepper value={1} onChange={() => {}} min={1} max={365} aria-label="d" />);
+    expect(screen.getByRole('button', { name: /decrease/i })).toBeDisabled();
+    cleanup();
+    render(<NumberStepper value={365} onChange={() => {}} min={1} max={365} aria-label="d2" />);
+    expect(screen.getByRole('button', { name: /increase/i })).toBeDisabled();
+  });
+
+  it('accepts a typed value, clamping above max', () => {
+    const { onChange } = setup(30);
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '500' } });
+    expect(onChange).toHaveBeenLastCalledWith(365);
+  });
+
+  it('accepts a typed in-range value as an integer', () => {
+    const { onChange } = setup(30);
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '12' } });
+    expect(onChange).toHaveBeenLastCalledWith(12);
+  });
+});

--- a/client/src/components/SyncConfig.jsx
+++ b/client/src/components/SyncConfig.jsx
@@ -1,6 +1,8 @@
 import { useState, useMemo } from 'react';
 import { formatLastSynced } from '../lib/courseDisplay.js';
 import TriCheckbox from './TriCheckbox.jsx';
+import { getSyncPrefs, setSyncPrefs } from '../lib/syncPrefs.js';
+import NumberStepper from './NumberStepper.jsx';
 
 const GROUPS = [
   { key: 'visible',  label: 'Visible courses',  match: (c) => !c.hidden && !c.archived && !c.excluded },
@@ -23,6 +25,8 @@ export default function SyncConfig({ courses, loggedIn, busy, onStart, onCancel,
   const [collapsed, setCollapsed] = useState({ visible: false, hidden: true });
 
   const [includeHidden, setIncludeHidden] = useState(false);
+  const [recentOnly, setRecentOnly] = useState(() => getSyncPrefs().recentOnly);
+  const [recentDays, setRecentDays] = useState(() => getSyncPrefs().recentDays);
 
   const hiddenCount = useMemo(
     () => courses.filter((c) => c.hidden && !c.archived && !c.excluded).length,
@@ -64,6 +68,33 @@ export default function SyncConfig({ courses, loggedIn, busy, onStart, onCancel,
             />
             <span>Include hidden courses{hiddenCount > 0 ? ` (${hiddenCount})` : ''}</span>
           </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={recentOnly}
+              onChange={(e) => setRecentOnly(e.target.checked)}
+            />
+            <span>Only check recent submissions</span>
+            <span
+              className="sync-help"
+              role="img"
+              aria-label="What recent-only skips"
+              title="Skips submission checks for assignments with no due date and those due more than N days ago. Courses, students, assignments, grades and mastery still sync fully."
+            >?</span>
+          </label>
+          {recentOnly && (
+            <div className="sync-recent-days">
+              <span>Due within</span>
+              <NumberStepper
+                value={recentDays}
+                onChange={setRecentDays}
+                min={1}
+                max={365}
+                aria-label="Day window"
+              />
+              <span>days</span>
+            </div>
+          )}
         </div>
       </div>
 
@@ -151,7 +182,10 @@ export default function SyncConfig({ courses, loggedIn, busy, onStart, onCancel,
           <button
             type="button"
             className="primary"
-            onClick={() => onStart([...selected], { includeHidden })}
+            onClick={() => {
+              setSyncPrefs({ recentOnly, recentDays });
+              onStart([...selected], { includeHidden, recentOnly, recentDays });
+            }}
             disabled={busy}
           >
             Start sync

--- a/client/src/components/SyncConfig.jsx
+++ b/client/src/components/SyncConfig.jsx
@@ -9,6 +9,9 @@ const GROUPS = [
   { key: 'hidden',   label: 'Hidden courses',   match: (c) => c.hidden && !c.archived && !c.excluded },
 ];
 
+const RECENT_HELP =
+  'Skips submission checks for assignments with no due date and those due more than the chosen number of days ago. Courses, students, assignments, grades and mastery still sync fully.';
+
 export default function SyncConfig({ courses, loggedIn, busy, onStart, onCancel, onLogin }) {
   const groups = useMemo(
     () => GROUPS.map((g) => ({ ...g, courses: courses.filter(g.match) })).filter((g) => g.courses.length),
@@ -28,6 +31,15 @@ export default function SyncConfig({ courses, loggedIn, busy, onStart, onCancel,
   const initialPrefs = useState(getSyncPrefs)[0];
   const [recentOnly, setRecentOnly] = useState(initialPrefs.recentOnly);
   const [recentDays, setRecentDays] = useState(initialPrefs.recentDays);
+  // Instant help popover for the recent-only "?" (mirrors the gradebook
+  // HelpDot/popover). Positioned fixed from the dot's rect so the modal's
+  // overflow can't clip it.
+  const [helpPos, setHelpPos] = useState(null);
+  const showHelp = (e) => {
+    const r = e.currentTarget.getBoundingClientRect();
+    setHelpPos({ left: r.left + r.width / 2, top: r.bottom + 8 });
+  };
+  const hideHelp = () => setHelpPos(null);
 
   const hiddenCount = useMemo(
     () => courses.filter((c) => c.hidden && !c.archived && !c.excluded).length,
@@ -69,21 +81,26 @@ export default function SyncConfig({ courses, loggedIn, busy, onStart, onCancel,
             />
             <span>Include hidden courses{hiddenCount > 0 ? ` (${hiddenCount})` : ''}</span>
           </label>
-          <label>
-            <input
-              type="checkbox"
-              checked={recentOnly}
-              onChange={(e) => setRecentOnly(e.target.checked)}
-            />
-            <span>Only check recent submissions</span>
+          <div className="sync-toggle-row">
+            <label>
+              <input
+                type="checkbox"
+                checked={recentOnly}
+                onChange={(e) => setRecentOnly(e.target.checked)}
+              />
+              <span>Include only recent submissions</span>
+            </label>
             <span
-              className="sync-help"
+              className="help-dot"
               role="img"
               tabIndex={0}
-              aria-label="Recent-only skips submission checks for assignments with no due date and those due more than N days ago. Courses, students, assignments, grades and mastery still sync fully."
-              title="Skips submission checks for assignments with no due date and those due more than N days ago. Courses, students, assignments, grades and mastery still sync fully."
+              aria-label={RECENT_HELP}
+              onMouseEnter={showHelp}
+              onMouseLeave={hideHelp}
+              onFocus={showHelp}
+              onBlur={hideHelp}
             >?</span>
-          </label>
+          </div>
           {recentOnly && (
             <div className="sync-recent-days">
               <span>Due within</span>
@@ -194,6 +211,12 @@ export default function SyncConfig({ courses, loggedIn, busy, onStart, onCancel,
           </button>
         </div>
       </div>
+
+      {helpPos && (
+        <div className="help-pop" role="tooltip" style={{ left: helpPos.left, top: helpPos.top }}>
+          {RECENT_HELP}
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/components/SyncConfig.jsx
+++ b/client/src/components/SyncConfig.jsx
@@ -25,8 +25,9 @@ export default function SyncConfig({ courses, loggedIn, busy, onStart, onCancel,
   const [collapsed, setCollapsed] = useState({ visible: false, hidden: true });
 
   const [includeHidden, setIncludeHidden] = useState(false);
-  const [recentOnly, setRecentOnly] = useState(() => getSyncPrefs().recentOnly);
-  const [recentDays, setRecentDays] = useState(() => getSyncPrefs().recentDays);
+  const initialPrefs = useState(getSyncPrefs)[0];
+  const [recentOnly, setRecentOnly] = useState(initialPrefs.recentOnly);
+  const [recentDays, setRecentDays] = useState(initialPrefs.recentDays);
 
   const hiddenCount = useMemo(
     () => courses.filter((c) => c.hidden && !c.archived && !c.excluded).length,
@@ -78,7 +79,8 @@ export default function SyncConfig({ courses, loggedIn, busy, onStart, onCancel,
             <span
               className="sync-help"
               role="img"
-              aria-label="What recent-only skips"
+              tabIndex={0}
+              aria-label="Recent-only skips submission checks for assignments with no due date and those due more than N days ago. Courses, students, assignments, grades and mastery still sync fully."
               title="Skips submission checks for assignments with no due date and those due more than N days ago. Courses, students, assignments, grades and mastery still sync fully."
             >?</span>
           </label>

--- a/client/src/components/SyncConfig.test.jsx
+++ b/client/src/components/SyncConfig.test.jsx
@@ -100,14 +100,14 @@ describe('SyncConfig', () => {
   it('reveals the day stepper only when "recent submissions" is checked', () => {
     renderConfig();
     expect(screen.queryByLabelText(/day window/i)).not.toBeInTheDocument();
-    fireEvent.click(screen.getByLabelText(/only check recent submissions/i));
+    fireEvent.click(screen.getByLabelText(/include only recent submissions/i));
     expect(screen.getByLabelText(/day window/i)).toBeInTheDocument();
   });
 
   it('passes recentOnly + recentDays on Start and persists them', () => {
     const onStart = vi.fn();
     renderConfig({ onStart });
-    fireEvent.click(screen.getByLabelText(/only check recent submissions/i));
+    fireEvent.click(screen.getByLabelText(/include only recent submissions/i));
     fireEvent.click(screen.getByRole('button', { name: /start sync/i }));
     expect(onStart).toHaveBeenCalledWith([1, 2], { includeHidden: false, recentOnly: true, recentDays: 30 });
     expect(localStorage.getItem('prism:sync:recent-only')).toBe('true');

--- a/client/src/components/SyncConfig.test.jsx
+++ b/client/src/components/SyncConfig.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import SyncConfig from './SyncConfig.jsx';
 
@@ -23,6 +23,8 @@ function renderConfig(props = {}) {
 }
 
 describe('SyncConfig', () => {
+  beforeEach(() => localStorage.clear());
+
   it('renders the visible and hidden course groups', () => {
     renderConfig();
     expect(screen.getByText(/Visible courses/)).toBeInTheDocument();
@@ -47,7 +49,7 @@ describe('SyncConfig', () => {
     fireEvent.click(screen.getByRole('button', { name: /start sync/i }));
     // onStart is called with the selected ids AND the include-hidden option
     // (default false). See SyncConfig's "Start sync" handler.
-    expect(onStart).toHaveBeenCalledWith([1, 2], { includeHidden: false });
+    expect(onStart).toHaveBeenCalledWith([1, 2], { includeHidden: false, recentOnly: false, recentDays: 30 });
   });
 
   it('group select-all checkbox is indeterminate when only some are selected', () => {
@@ -93,5 +95,21 @@ describe('SyncConfig', () => {
     renderConfig();
     // Biology 9 is in the (expanded) visible group; its synced_at renders a line.
     expect(screen.getByText(/synced 20\/05\/2026/)).toBeInTheDocument();
+  });
+
+  it('reveals the day stepper only when "recent submissions" is checked', () => {
+    renderConfig();
+    expect(screen.queryByLabelText(/day window/i)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText(/only check recent submissions/i));
+    expect(screen.getByLabelText(/day window/i)).toBeInTheDocument();
+  });
+
+  it('passes recentOnly + recentDays on Start and persists them', () => {
+    const onStart = vi.fn();
+    renderConfig({ onStart });
+    fireEvent.click(screen.getByLabelText(/only check recent submissions/i));
+    fireEvent.click(screen.getByRole('button', { name: /start sync/i }));
+    expect(onStart).toHaveBeenCalledWith([1, 2], { includeHidden: false, recentOnly: true, recentDays: 30 });
+    expect(localStorage.getItem('prism:sync:recent-only')).toBe('true');
   });
 });

--- a/client/src/components/SyncDialog.jsx
+++ b/client/src/components/SyncDialog.jsx
@@ -32,13 +32,13 @@ export default function SyncDialog({ onClose, onSyncComplete }) {
   // events). The running-mode overlay is intentionally non-dismissable —
   // there is no backdrop/Escape handler — so the stream always runs to
   // completion and needs no abort path.
-  async function startSync(masteryCourseIds, { skipSchoology = false, includeHidden = false } = {}) {
+  async function startSync(masteryCourseIds, { skipSchoology = false, includeHidden = false, recentOnly = false, recentDays = 30 } = {}) {
     setEvents([]);
     setMetrics(null);
     setMode('running');
     let streamCompleted = false;
     try {
-      await runSync({ masteryCourseIds, skipSchoology, includeHidden }, (evt) => {
+      await runSync({ masteryCourseIds, skipSchoology, includeHidden, recentOnly, recentDays }, (evt) => {
         setEvents((prev) => [...prev, evt]);
       });
       streamCompleted = true;

--- a/client/src/lib/syncPrefs.js
+++ b/client/src/lib/syncPrefs.js
@@ -1,0 +1,35 @@
+// #55: remembers the teacher's last-used "recent submissions only" choice so the
+// Sync dialog can pre-fill it. Per-browser; the server stays stateless and only
+// receives explicit per-request params.
+
+const KEY_ON = 'prism:sync:recent-only';
+const KEY_DAYS = 'prism:sync:recent-days';
+
+// Coerce a day value to a positive integer in [1, 365]; non-numbers → fallback.
+export function clampDays(value, fallback = 30) {
+  if (value == null) return fallback;
+  const n = Math.floor(Number(value));
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(365, Math.max(1, n));
+}
+
+export function getSyncPrefs() {
+  try {
+    return {
+      recentOnly: localStorage.getItem(KEY_ON) === 'true',
+      recentDays: clampDays(localStorage.getItem(KEY_DAYS)),
+    };
+  } catch {
+    // localStorage unavailable (private mode) — fall back to defaults.
+    return { recentOnly: false, recentDays: 30 };
+  }
+}
+
+export function setSyncPrefs({ recentOnly, recentDays }) {
+  try {
+    localStorage.setItem(KEY_ON, recentOnly ? 'true' : 'false');
+    localStorage.setItem(KEY_DAYS, String(clampDays(recentDays)));
+  } catch {
+    // localStorage unavailable (private mode / quota) — degrade silently.
+  }
+}

--- a/client/src/lib/syncPrefs.test.js
+++ b/client/src/lib/syncPrefs.test.js
@@ -12,6 +12,16 @@ describe('getSyncPrefs', () => {
     setSyncPrefs({ recentOnly: true, recentDays: 9999 });
     expect(getSyncPrefs()).toEqual({ recentOnly: true, recentDays: 365 });
   });
+
+  it('falls back to the default day window when the stored value is non-numeric', () => {
+    localStorage.setItem('prism:sync:recent-days', 'corrupt');
+    expect(getSyncPrefs().recentDays).toBe(30);
+  });
+
+  it('reads recentOnly false back from a stored "false"', () => {
+    setSyncPrefs({ recentOnly: false, recentDays: 30 });
+    expect(getSyncPrefs().recentOnly).toBe(false);
+  });
 });
 
 describe('setSyncPrefs', () => {

--- a/client/src/lib/syncPrefs.test.js
+++ b/client/src/lib/syncPrefs.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getSyncPrefs, setSyncPrefs, clampDays } from './syncPrefs.js';
+
+beforeEach(() => localStorage.clear());
+
+describe('getSyncPrefs', () => {
+  it('returns the defaults (off / 30) when nothing is stored', () => {
+    expect(getSyncPrefs()).toEqual({ recentOnly: false, recentDays: 30 });
+  });
+
+  it('reads back a stored pref, clamping the day value', () => {
+    setSyncPrefs({ recentOnly: true, recentDays: 9999 });
+    expect(getSyncPrefs()).toEqual({ recentOnly: true, recentDays: 365 });
+  });
+});
+
+describe('setSyncPrefs', () => {
+  it('round-trips through localStorage', () => {
+    setSyncPrefs({ recentOnly: true, recentDays: 45 });
+    expect(getSyncPrefs()).toEqual({ recentOnly: true, recentDays: 45 });
+  });
+});
+
+describe('clampDays', () => {
+  it('floors and clamps into 1..365, defaulting on non-numbers', () => {
+    expect(clampDays(45)).toBe(45);
+    expect(clampDays(0)).toBe(1);
+    expect(clampDays(500)).toBe(365);
+    expect(clampDays('x')).toBe(30);
+  });
+});

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -61,13 +61,13 @@ export const getSyncMetrics = () => request('/sync/metrics');
 // Run the unified sync. Streams newline-delimited JSON progress events from the
 // server; each parsed event is passed to onEvent. Resolves when the stream ends.
 export async function runSync(
-  { masteryCourseIds = [], skipSchoology = false, includeHidden = false },
+  { masteryCourseIds = [], skipSchoology = false, includeHidden = false, recentOnly = false, recentDays = 30 },
   onEvent
 ) {
   const res = await fetch(`${BASE}/sync`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ masteryCourseIds, skipSchoology, includeHidden }),
+    body: JSON.stringify({ masteryCourseIds, skipSchoology, includeHidden, recentOnly, recentDays }),
   });
   if (res.status === 409) throw new Error('A sync is already running.');
   if (!res.ok) {

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -131,6 +131,38 @@ so they compose without clashing with the border.
   badge — an actionable "regrade me" signal, distinct from the teacher's
   Prism-local "Ask to resubmit" flag.
 
+### Help affordance — `.help-dot` + instant popover (first shared extraction)
+A stand-out circular **?** that reveals an **instant** popover on hover/focus —
+no native-`title` delay. First built inline as the gradebook `HelpDot`
+(`CoursePage.jsx`); now extracted to reusable `app.css` classes and used by the
+Sync dialog's recent-only control (June 2026).
+- **`.help-dot`** — 16px circle, `var(--accent-subtle)` fill, `1px solid
+  var(--accent)` border, accent **?**, `cursor: help`. Hover/focus → fills
+  `var(--accent)` with a white glyph, so it reads as interactive and stands out
+  enough to be noticed.
+- **`.help-pop`** — `position: fixed` box placed from the dot's
+  `getBoundingClientRect()` (fixed so a modal's `overflow` can't clip it);
+  `var(--card-bg)` + `1px solid var(--border)` + `0 8px 28px rgba(0,0,0,.18)`
+  shadow, `pointer-events: none`. Appears the instant the dot is hovered/focused.
+- **A11y:** the dot carries the full explanation as `aria-label` (screen readers
+  don't need the popover) and sits *outside* the `<label>` so clicking it never
+  toggles the control.
+- Follow-up: migrate the gradebook's inline `HelpDot`/popover onto these classes.
+
+### Number stepper — `.number-stepper` (`[−] N [+]`)
+A bounded integer input that reads as a *value*, not a form field, until edited.
+- One bordered pill wraps prominent filled **`.number-stepper__btn`** −/+ controls
+  (`var(--bg-subtle)`, accent glyph, ~1.9rem hit target; hover fills accent/white)
+  flanking a borderless, transparent, centred number.
+- Native `type=number` spinner arrows are hidden (`appearance: textfield` +
+  `::-webkit-*-spin-button`) so digits never clip; the number gains a
+  `var(--bg-subtle)` wash only on `:focus` — "plain text until you click it."
+
+### Opt-in toggle phrasing
+Scope-narrowing checkboxes in the same cluster share a verb for parallelism:
+`Include hidden courses` / `Include only recent submissions` — not a mix of
+"Include…" and "Only check…".
+
 ---
 
 ## Open questions (resolve in the brainstorm)
@@ -165,3 +197,8 @@ so they compose without clashing with the border.
 control band, the comment publish indicator, and the whole-class command bar.
 `client/src/app.css` — the semantic CSS variables and the existing `.badge` /
 button classes.
+
+**First reusable extractions (Phase 2 started, June 2026):** `.help-dot` /
+`.help-pop` and `.number-stepper` (component: `client/src/components/NumberStepper.jsx`)
+now live as shared classes in `client/src/app.css` — used by the Sync dialog.
+New UI should reuse these rather than re-inlining a help "?" or a number spinner.

--- a/docs/superpowers/plans/2026-06-06-recent-only-submission-sync.md
+++ b/docs/superpowers/plans/2026-06-06-recent-only-submission-sync.md
@@ -1,0 +1,803 @@
+# Recent-only Submission-Status Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the teacher opt into restricting the slow per-`(assignment × student)` submission-status check to assignments due in the last N days or in the future, skipping undated and clearly-old work — cutting sync wall time (#55).
+
+**Architecture:** A pure server helper filters the dropbox-assignment list by due date inside `syncSectionData`; the `recentOnly`/`recentDays` flags thread from the Sync dialog → `POST /api/sync` → `runUnifiedSync` → `fullSync` → `syncSectionData`. The teacher's last-used choice is remembered in browser `localStorage` and overridable per sync via a checkbox + `[−] N [+]` stepper in the dialog. The server is stateless about the default — it only ever receives explicit per-request params, validated/clamped server-side.
+
+**Tech Stack:** Express + better-sqlite3 (server, ESM), React + Vite (client), Vitest + @testing-library/react (tests).
+
+**Spec:** `docs/superpowers/specs/2026-06-06-recent-only-submission-sync-design.md`
+
+---
+
+## File Structure
+
+**Server**
+- `server/services/recentWindow.js` — **new** pure helpers `filterRecentAssignments(assignments, recentOnly, recentDays, now)` and `clampDays(value, fallback)`. No I/O; unit-tested.
+- `server/services/recentWindow.test.js` — **new** unit tests.
+- `server/services/sync.js` — destructure `recentOnly`/`recentDays` in `syncSectionData`; window the dropbox list; return `windowSkipped`; thread the two opts through `fullSync`.
+- `server/services/syncOrchestrator.js` — thread the two opts through `runUnifiedSync` → `fullSync`.
+- `server/services/sync.test.js` — **extend** with a recent-window describe block.
+- `server/routes/schoology.js` — parse + clamp the two params on `POST /sync`; pass into `runUnifiedSync`.
+- `server/routes/schoology.test.js` — **extend** with param pass-through/clamp tests.
+
+**Client**
+- `client/src/lib/syncPrefs.js` — **new** `getSyncPrefs()`, `setSyncPrefs()`, `clampDays()` over `localStorage`.
+- `client/src/lib/syncPrefs.test.js` — **new** unit tests.
+- `client/src/components/NumberStepper.jsx` — **new** reusable `[−] N [+]` integer stepper.
+- `client/src/components/NumberStepper.test.jsx` — **new** unit tests.
+- `client/src/components/SyncConfig.jsx` — add the recent-only checkbox + stepper + "?" tooltip; seed from prefs; include the two opts in `onStart`; persist on Start.
+- `client/src/components/SyncConfig.test.jsx` — **extend** (and update the existing `onStart` assertion).
+- `client/src/components/SyncDialog.jsx` — thread the two opts through `startSync` → `runSync`.
+- `client/src/services/api.js` — include the two opts in the `runSync` POST body.
+
+**Slice order:** Tasks 1–3 are server-only and ship the capability (the perf win is live for any caller sending the params). Tasks 4–6 add the client control. Each task ends green.
+
+---
+
+## Task 1: Pure window-filter helper
+
+**Files:**
+- Create: `server/services/recentWindow.js`
+- Test: `server/services/recentWindow.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/services/recentWindow.test.js`:
+
+```js
+import { describe, it, expect } from 'vitest';
+import { filterRecentAssignments, clampDays } from './recentWindow.js';
+
+// Fixed reference instant → cutoff for 30 days is 2026-05-07.
+const NOW = '2026-06-06T00:00:00.000Z';
+const recent = { id: 'r', due: '2026-06-01' };  // within window
+const old = { id: 'o', due: '2026-01-01' };     // > 30 days ago
+const future = { id: 'f', due: '2026-12-01' };  // not yet due
+const undated = { id: 'u', due: null };         // no due date
+const all = [recent, old, future, undated];
+
+describe('filterRecentAssignments', () => {
+  it('passes everything through with no skips when recentOnly is off', () => {
+    expect(filterRecentAssignments(all, false, 30, NOW)).toEqual({ target: all, windowSkipped: 0 });
+  });
+
+  it('keeps recent + future dated, skips old + undated when recentOnly is on', () => {
+    const { target, windowSkipped } = filterRecentAssignments(all, true, 30, NOW);
+    expect(target.map((a) => a.id)).toEqual(['r', 'f']);
+    expect(windowSkipped).toBe(2);
+  });
+
+  it('treats an unparseable due date as undated (skipped)', () => {
+    const { target } = filterRecentAssignments([{ id: 'x', due: 'not-a-date' }], true, 30, NOW);
+    expect(target).toEqual([]);
+  });
+
+  it('widens the window with a larger recentDays', () => {
+    const { target } = filterRecentAssignments(all, true, 365, NOW);
+    expect(target.map((a) => a.id)).toEqual(['r', 'o', 'f']); // old now inside 365d
+  });
+});
+
+describe('clampDays', () => {
+  it('floors and clamps into 1..365, defaulting on non-numbers', () => {
+    expect(clampDays(30)).toBe(30);
+    expect(clampDays(0)).toBe(1);
+    expect(clampDays(500)).toBe(365);
+    expect(clampDays(12.9)).toBe(12);
+    expect(clampDays('abc')).toBe(30);
+    expect(clampDays(undefined)).toBe(30);
+    expect(clampDays(50, 7)).toBe(50);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run server/services/recentWindow.test.js`
+Expected: FAIL — `Failed to resolve import "./recentWindow.js"` (module does not exist).
+
+- [ ] **Step 3: Implement the helper**
+
+Create `server/services/recentWindow.js`:
+
+```js
+// #55: pure helpers for the recent-only submission-status window. No I/O.
+
+const DAY_MS = 86400000;
+
+// Restrict a list of assignments to those whose submission status is worth the
+// expensive per-cell check: due within the last `recentDays` days, or due in
+// the future. Undated and clearly-old assignments are dropped. When `recentOnly`
+// is false this is a pass-through. `now` is an ISO string (the sync's reference
+// timestamp), so it must be parsed before arithmetic.
+export function filterRecentAssignments(assignments, recentOnly, recentDays, now) {
+  if (!recentOnly) return { target: assignments, windowSkipped: 0 };
+  const cutoff = Date.parse(now) - recentDays * DAY_MS;
+  const target = assignments.filter((a) => {
+    const t = a.due ? Date.parse(a.due) : NaN;
+    return !Number.isNaN(t) && t >= cutoff;
+  });
+  return { target, windowSkipped: assignments.length - target.length };
+}
+
+// Coerce a day-window value to a positive integer in [1, 365]; non-numbers fall
+// back to `fallback`. Shared by the route (trust boundary) and syncSectionData.
+export function clampDays(value, fallback = 30) {
+  const n = Math.floor(Number(value));
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(365, Math.max(1, n));
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run server/services/recentWindow.test.js`
+Expected: PASS (7 assertions across 2 describes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/services/recentWindow.js server/services/recentWindow.test.js
+git commit -m "feat(sync): add recent-window assignment filter + clampDays helper (#55)"
+```
+
+---
+
+## Task 2: Window the submission loop + thread opts through fullSync
+
+**Files:**
+- Modify: `server/services/sync.js` (imports ~L15; `syncSectionData` opts ~L58; dropbox list ~L212; return ~L355; `fullSync` ~L605 + the `syncSectionData` call ~L723)
+- Modify: `server/services/syncOrchestrator.js` (`runUnifiedSync` ~L23 + `fullSync` call ~L34)
+- Test: `server/services/sync.test.js` (add a describe block)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `server/services/sync.test.js` (a new top-level `describe`, after the existing `syncSectionData` blocks):
+
+```js
+describe('syncSectionData — recent-only submission window (#55)', () => {
+  let db;
+  let courseId;
+  const NOW = '2026-06-06T00:00:00.000Z'; // 30-day cutoff = 2026-05-07
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    migrate(db);
+    courseId = db.prepare(
+      `INSERT INTO courses (schoology_section_id, course_name) VALUES ('sec-w', 'Window')`
+    ).run().lastInsertRowid;
+    getSectionEnrollments.mockReset();
+    getSectionAssignments.mockReset();
+    getSectionGrades.mockReset();
+    getSubmissionStatus.mockReset();
+    getSectionGrades.mockResolvedValue([]);
+    getSubmissionStatus.mockResolvedValue(null);
+    getSectionEnrollments.mockResolvedValue([
+      { id: '900001', uid: '700001', name_first: 'Ada', name_last: 'Lovelace', admin: '0' },
+      { id: '900002', uid: '700002', name_first: 'Alan', name_last: 'Turing', admin: '0' },
+    ]);
+    getSectionAssignments.mockResolvedValue([
+      { id: '5001', title: 'Recent',  published: 1, allow_dropbox: '1', due: '2026-06-01' },
+      { id: '5002', title: 'Old',     published: 1, allow_dropbox: '1', due: '2026-01-01' },
+      { id: '5003', title: 'Undated', published: 1, allow_dropbox: '1', due: null },
+    ]);
+  });
+
+  test('recentOnly skips old + undated dropbox assignments', async () => {
+    const result = await syncSectionData(db, 'sec-w', courseId, NOW, { recentOnly: true, recentDays: 30 });
+    expect(getSubmissionStatus).toHaveBeenCalledTimes(2); // 1 recent assignment × 2 students
+    expect(result.windowSkipped).toBe(2);
+  });
+
+  test('recentOnly off checks every dropbox assignment (unchanged)', async () => {
+    const result = await syncSectionData(db, 'sec-w', courseId, NOW, { recentOnly: false });
+    expect(getSubmissionStatus).toHaveBeenCalledTimes(6); // 3 assignments × 2 students
+    expect(result.windowSkipped).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run server/services/sync.test.js -t "recent-only submission window"`
+Expected: FAIL — `result.windowSkipped` is `undefined`, and the recentOnly case still calls `getSubmissionStatus` 6 times (no filter applied yet).
+
+- [ ] **Step 3: Add the helper import to `sync.js`**
+
+After the `import { runWithLimits } from './rateLimitedRunner.js';` line (~L16), add:
+
+```js
+import { filterRecentAssignments } from './recentWindow.js';
+```
+
+- [ ] **Step 4: Destructure the two opts in `syncSectionData`**
+
+Replace the opts destructure (~L58):
+
+```js
+  const {
+    submissionConcurrency = 2,
+    submissionRatePerSec = 4,
+    submissionAbandonAfter = 5,
+    skipSubmissions = false,
+    recentOnly = false,
+    recentDays = 30,
+  } = opts;
+```
+
+- [ ] **Step 5: Window the dropbox list**
+
+Replace the `dropboxAssignments` construction (~L212):
+
+```js
+  const dropboxAll = skipSubmissions
+    ? []
+    : assignments.filter(a => a.allow_dropbox === '1' || a.allow_dropbox === 1);
+  // #55: when recentOnly, restrict the per-cell submission check to assignments
+  // due within recentDays or in the future; skip undated + clearly-old work.
+  const { target: dropboxAssignments, windowSkipped } =
+    filterRecentAssignments(dropboxAll, recentOnly, recentDays, now);
+```
+
+(The downstream `for (const a of dropboxAssignments)` loop is unchanged — the variable name is preserved.)
+
+- [ ] **Step 6: Return `windowSkipped`**
+
+In the `syncSectionData` return object (~L355), add the field after `submissionSkipped,`:
+
+```js
+    submissionSkipped,
+    windowSkipped,
+    rateLimitHits,
+```
+
+- [ ] **Step 7: Run the window tests to verify they pass**
+
+Run: `npx vitest run server/services/sync.test.js -t "recent-only submission window"`
+Expected: PASS (both tests).
+
+- [ ] **Step 8: Thread the opts through `fullSync`**
+
+Extend the `fullSync` signature (~L605):
+
+```js
+export async function fullSync(onProgress, { includeHidden = false, recentOnly = false, recentDays = 30 } = {}) {
+```
+
+And in the `syncSectionData` call (~L723), add the two opts to the explicit options object:
+
+```js
+      const result = await syncSectionData(db, sectionId, courseRow.id, now, {
+        ...syncConfig,
+        recentOnly,
+        recentDays,
+        fetchSubmissionLookup: submissionFetcher ? (sid) => submissionFetcher.fetch(sid) : undefined,
+      });
+```
+
+- [ ] **Step 9: Thread the opts through `runUnifiedSync`**
+
+In `server/services/syncOrchestrator.js`, extend the `runUnifiedSync` destructure (~L23):
+
+```js
+export async function runUnifiedSync(
+  { masteryCourseIds = [], skipSchoology = false, includeHidden = false, recentOnly = false, recentDays = 30 },
+  onEvent
+) {
+```
+
+And the `fullSync` call (~L34):
+
+```js
+      const result = await fullSync(
+        (progress) => emit({ type: 'log', message: progress.message }),
+        { includeHidden, recentOnly, recentDays }
+      );
+```
+
+- [ ] **Step 10: Run the full server suite**
+
+Run: `npx vitest run server/`
+Expected: PASS — all existing server suites green plus the two new window tests.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add server/services/sync.js server/services/syncOrchestrator.js server/services/sync.test.js
+git commit -m "feat(sync): window the submission-status loop by due date (#55)"
+```
+
+---
+
+## Task 3: Accept + validate the params on `POST /api/sync`
+
+**Files:**
+- Modify: `server/routes/schoology.js` (`POST /sync` body destructure, ~L23)
+- Test: `server/routes/schoology.test.js` (add a describe block)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `server/routes/schoology.test.js` a new describe block (after the existing `POST /api/sync` block). It captures the opts the route hands to `runUnifiedSync` via the existing `h.impl` mock:
+
+```js
+describe('POST /api/sync — recent-only params (#55)', () => {
+  let captured;
+  beforeEach(() => {
+    captured = null;
+    h.impl = async (opts, onEvent) => {
+      captured = opts;
+      onEvent({ type: 'summary', schoology: null, mastery: [], elapsedMs: 1 });
+    };
+  });
+
+  async function post(body) {
+    const { server, port } = startServer();
+    try {
+      const res = await fetch(`http://localhost:${port}/api/sync`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      await res.text(); // drain the ndjson stream
+    } finally {
+      server.close();
+    }
+  }
+
+  test('defaults to recentOnly false / 30 days when omitted', async () => {
+    await post({ masteryCourseIds: [] });
+    expect(captured.recentOnly).toBe(false);
+    expect(captured.recentDays).toBe(30);
+  });
+
+  test('passes through recentOnly and clamps recentDays into 1..365', async () => {
+    await post({ recentOnly: true, recentDays: 9999 });
+    expect(captured.recentOnly).toBe(true);
+    expect(captured.recentDays).toBe(365);
+  });
+
+  test('coerces a non-numeric recentDays to the default', async () => {
+    await post({ recentOnly: true, recentDays: 'abc' });
+    expect(captured.recentDays).toBe(30);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run server/routes/schoology.test.js -t "recent-only params"`
+Expected: FAIL — `captured.recentOnly` / `captured.recentDays` are `undefined` (the route does not read or forward them yet).
+
+- [ ] **Step 3: Add the `clampDays` import**
+
+At the top of `server/routes/schoology.js`, with the other imports, add:
+
+```js
+import { clampDays } from '../services/recentWindow.js';
+```
+
+- [ ] **Step 4: Parse, clamp, and forward the params**
+
+In the `POST /sync` handler, replace the body destructure + `runUnifiedSync` call:
+
+```js
+  const {
+    masteryCourseIds = [],
+    skipSchoology = false,
+    includeHidden = false,
+    recentOnly = false,
+    recentDays = 30,
+  } = req.body || {};
+```
+
+and (a few lines down) the call:
+
+```js
+    await runUnifiedSync(
+      { masteryCourseIds, skipSchoology, includeHidden, recentOnly: !!recentOnly, recentDays: clampDays(recentDays) },
+      write,
+    );
+```
+
+- [ ] **Step 5: Run the route tests + full server suite**
+
+Run: `npx vitest run server/routes/schoology.test.js && npx vitest run server/`
+Expected: PASS — the three new param tests pass and the existing `POST /api/sync` stream/409 tests stay green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/routes/schoology.js server/routes/schoology.test.js
+git commit -m "feat(sync): accept + clamp recentOnly/recentDays on POST /api/sync (#55)"
+```
+
+---
+
+## Task 4: Client `localStorage` prefs helper
+
+**Files:**
+- Create: `client/src/lib/syncPrefs.js`
+- Test: `client/src/lib/syncPrefs.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `client/src/lib/syncPrefs.test.js`:
+
+```js
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getSyncPrefs, setSyncPrefs, clampDays } from './syncPrefs.js';
+
+beforeEach(() => localStorage.clear());
+
+describe('getSyncPrefs', () => {
+  it('returns the defaults (off / 30) when nothing is stored', () => {
+    expect(getSyncPrefs()).toEqual({ recentOnly: false, recentDays: 30 });
+  });
+
+  it('reads back a stored pref, clamping the day value', () => {
+    setSyncPrefs({ recentOnly: true, recentDays: 9999 });
+    expect(getSyncPrefs()).toEqual({ recentOnly: true, recentDays: 365 });
+  });
+});
+
+describe('setSyncPrefs', () => {
+  it('round-trips through localStorage', () => {
+    setSyncPrefs({ recentOnly: true, recentDays: 45 });
+    expect(getSyncPrefs()).toEqual({ recentOnly: true, recentDays: 45 });
+  });
+});
+
+describe('clampDays', () => {
+  it('floors and clamps into 1..365, defaulting on non-numbers', () => {
+    expect(clampDays(45)).toBe(45);
+    expect(clampDays(0)).toBe(1);
+    expect(clampDays(500)).toBe(365);
+    expect(clampDays('x')).toBe(30);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd client && npx vitest run src/lib/syncPrefs.test.js`
+Expected: FAIL — `Failed to resolve import "./syncPrefs.js"`.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `client/src/lib/syncPrefs.js` (mirrors the try/catch localStorage pattern of `assessmentDraft.js`):
+
+```js
+// #55: remembers the teacher's last-used "recent submissions only" choice so the
+// Sync dialog can pre-fill it. Per-browser; the server stays stateless and only
+// receives explicit per-request params.
+
+const KEY_ON = 'prism:sync:recent-only';
+const KEY_DAYS = 'prism:sync:recent-days';
+
+// Coerce a day value to a positive integer in [1, 365]; non-numbers → fallback.
+export function clampDays(value, fallback = 30) {
+  const n = Math.floor(Number(value));
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(365, Math.max(1, n));
+}
+
+export function getSyncPrefs() {
+  try {
+    return {
+      recentOnly: localStorage.getItem(KEY_ON) === 'true',
+      recentDays: clampDays(localStorage.getItem(KEY_DAYS)),
+    };
+  } catch {
+    // localStorage unavailable (private mode) — fall back to defaults.
+    return { recentOnly: false, recentDays: 30 };
+  }
+}
+
+export function setSyncPrefs({ recentOnly, recentDays }) {
+  try {
+    localStorage.setItem(KEY_ON, recentOnly ? 'true' : 'false');
+    localStorage.setItem(KEY_DAYS, String(clampDays(recentDays)));
+  } catch {
+    // localStorage unavailable (private mode / quota) — degrade silently.
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd client && npx vitest run src/lib/syncPrefs.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/lib/syncPrefs.js client/src/lib/syncPrefs.test.js
+git commit -m "feat(sync): add syncPrefs localStorage helper (#55)"
+```
+
+---
+
+## Task 5: `NumberStepper` component
+
+**Files:**
+- Create: `client/src/components/NumberStepper.jsx`
+- Test: `client/src/components/NumberStepper.test.jsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `client/src/components/NumberStepper.test.jsx`:
+
+```jsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import NumberStepper from './NumberStepper.jsx';
+
+function setup(value = 30) {
+  const onChange = vi.fn();
+  render(<NumberStepper value={value} onChange={onChange} min={1} max={365} aria-label="Day window" />);
+  return { onChange };
+}
+
+describe('NumberStepper', () => {
+  it('increments and decrements by one', () => {
+    const { onChange } = setup(30);
+    fireEvent.click(screen.getByRole('button', { name: /increase/i }));
+    expect(onChange).toHaveBeenCalledWith(31);
+    fireEvent.click(screen.getByRole('button', { name: /decrease/i }));
+    expect(onChange).toHaveBeenCalledWith(29);
+  });
+
+  it('disables the buttons at the bounds', () => {
+    render(<NumberStepper value={1} onChange={() => {}} min={1} max={365} aria-label="d" />);
+    expect(screen.getByRole('button', { name: /decrease/i })).toBeDisabled();
+    render(<NumberStepper value={365} onChange={() => {}} min={1} max={365} aria-label="d2" />);
+    expect(screen.getByRole('button', { name: /increase/i })).toBeDisabled();
+  });
+
+  it('accepts a typed value, clamping above max', () => {
+    const { onChange } = setup(30);
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '500' } });
+    expect(onChange).toHaveBeenLastCalledWith(365);
+  });
+
+  it('accepts a typed in-range value as an integer', () => {
+    const { onChange } = setup(30);
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '12' } });
+    expect(onChange).toHaveBeenLastCalledWith(12);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd client && npx vitest run src/components/NumberStepper.test.jsx`
+Expected: FAIL — `Failed to resolve import "./NumberStepper.jsx"`.
+
+- [ ] **Step 3: Implement the component**
+
+Create `client/src/components/NumberStepper.jsx` (follows the small controlled-input pattern of `TriCheckbox.jsx`; uses existing button classes per the theming convention):
+
+```jsx
+// A controlled [−] N [+] integer stepper. Emits clamped integer values via
+// onChange. Non-numeric typed input is ignored (the field stays controlled).
+export default function NumberStepper({ value, onChange, min = 1, max = 365, ...rest }) {
+  const clamp = (n) => Math.min(max, Math.max(min, Math.floor(n)));
+  const emit = (n) => { if (Number.isFinite(n)) onChange(clamp(n)); };
+  return (
+    <span className="number-stepper">
+      <button
+        type="button" className="ghost" aria-label="Decrease"
+        onClick={() => emit(value - 1)} disabled={value <= min}
+      >−</button>
+      <input
+        type="number" inputMode="numeric" min={min} max={max} value={value}
+        onChange={(e) => { const n = parseInt(e.target.value, 10); if (!Number.isNaN(n)) emit(n); }}
+        {...rest}
+      />
+      <button
+        type="button" className="ghost" aria-label="Increase"
+        onClick={() => emit(value + 1)} disabled={value >= max}
+      >+</button>
+    </span>
+  );
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd client && npx vitest run src/components/NumberStepper.test.jsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/components/NumberStepper.jsx client/src/components/NumberStepper.test.jsx
+git commit -m "feat(sync): add NumberStepper component (#55)"
+```
+
+---
+
+## Task 6: Wire the control into the Sync dialog
+
+**Files:**
+- Modify: `client/src/components/SyncConfig.jsx` (imports; state; Step 1 markup ~L60; Start handler ~L210)
+- Modify: `client/src/components/SyncConfig.test.jsx` (update the existing `onStart` assertion; add new tests)
+- Modify: `client/src/components/SyncDialog.jsx` (`startSync` ~L35 + `runSync` call ~L41)
+- Modify: `client/src/services/api.js` (`runSync` ~L63)
+
+- [ ] **Step 1: Update the existing assertion + write the new failing tests**
+
+In `client/src/components/SyncConfig.test.jsx`:
+
+(a) Add a localStorage reset at the top of the `describe('SyncConfig', ...)` block so prefs default deterministically:
+
+```jsx
+import { beforeEach } from 'vitest';
+// ...inside describe('SyncConfig', () => {
+  beforeEach(() => localStorage.clear());
+```
+
+(b) Update the existing assertion (currently line ~50) to include the new opts:
+
+```jsx
+    expect(onStart).toHaveBeenCalledWith([1, 2], { includeHidden: false, recentOnly: false, recentDays: 30 });
+```
+
+(c) Add new tests inside the same describe:
+
+```jsx
+  it('reveals the day stepper only when "recent submissions" is checked', () => {
+    renderConfig();
+    expect(screen.queryByLabelText(/day window/i)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText(/only check recent submissions/i));
+    expect(screen.getByLabelText(/day window/i)).toBeInTheDocument();
+  });
+
+  it('passes recentOnly + recentDays on Start and persists them', () => {
+    const onStart = vi.fn();
+    renderConfig({ onStart });
+    fireEvent.click(screen.getByLabelText(/only check recent submissions/i));
+    fireEvent.click(screen.getByRole('button', { name: /start sync/i }));
+    expect(onStart).toHaveBeenCalledWith([1, 2], { includeHidden: false, recentOnly: true, recentDays: 30 });
+    expect(localStorage.getItem('prism:sync:recent-only')).toBe('true');
+  });
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd client && npx vitest run src/components/SyncConfig.test.jsx`
+Expected: FAIL — the control does not exist; the updated assertion and the two new tests fail.
+
+- [ ] **Step 3: Add imports + state to `SyncConfig.jsx`**
+
+At the top of `SyncConfig.jsx`, add imports:
+
+```jsx
+import { getSyncPrefs, setSyncPrefs } from '../lib/syncPrefs.js';
+import NumberStepper from './NumberStepper.jsx';
+```
+
+Inside the component body (next to the existing `const [includeHidden, setIncludeHidden] = useState(false);`), seed from prefs:
+
+```jsx
+  const [recentOnly, setRecentOnly] = useState(() => getSyncPrefs().recentOnly);
+  const [recentDays, setRecentDays] = useState(() => getSyncPrefs().recentDays);
+```
+
+- [ ] **Step 4: Add the control markup in Step 1**
+
+In the `sync-step-toggles` div (Step 1), directly after the existing "Include hidden courses" `<label>`, add:
+
+```jsx
+          <label>
+            <input
+              type="checkbox"
+              checked={recentOnly}
+              onChange={(e) => setRecentOnly(e.target.checked)}
+            />
+            <span>Only check recent submissions</span>
+            <span
+              className="sync-help"
+              role="img"
+              aria-label="What recent-only skips"
+              title="Skips submission checks for assignments with no due date and those due more than N days ago. Courses, students, assignments, grades and mastery still sync fully."
+            >?</span>
+          </label>
+          {recentOnly && (
+            <div className="sync-recent-days">
+              <span>Due within</span>
+              <NumberStepper
+                value={recentDays}
+                onChange={setRecentDays}
+                min={1}
+                max={365}
+                aria-label="Day window"
+              />
+              <span>days</span>
+            </div>
+          )}
+```
+
+- [ ] **Step 5: Persist + forward the opts in the Start handler**
+
+Replace the Start button `onClick` (~L210):
+
+```jsx
+            onClick={() => {
+              setSyncPrefs({ recentOnly, recentDays });
+              onStart([...selected], { includeHidden, recentOnly, recentDays });
+            }}
+```
+
+- [ ] **Step 6: Run the SyncConfig tests to verify they pass**
+
+Run: `cd client && npx vitest run src/components/SyncConfig.test.jsx`
+Expected: PASS — updated assertion + the two new tests, with the pre-existing tests still green.
+
+- [ ] **Step 7: Thread the opts through `SyncDialog.jsx`**
+
+Replace the `startSync` signature (~L35) and the `runSync` call (~L41):
+
+```jsx
+  async function startSync(masteryCourseIds, { skipSchoology = false, includeHidden = false, recentOnly = false, recentDays = 30 } = {}) {
+    setEvents([]);
+    setMetrics(null);
+    setMode('running');
+    let streamCompleted = false;
+    try {
+      await runSync({ masteryCourseIds, skipSchoology, includeHidden, recentOnly, recentDays }, (evt) => {
+        setEvents((prev) => [...prev, evt]);
+      });
+```
+
+- [ ] **Step 8: Forward the opts in `runSync` (`api.js`)**
+
+Replace the `runSync` destructure + POST body (~L63):
+
+```js
+export async function runSync(
+  { masteryCourseIds = [], skipSchoology = false, includeHidden = false, recentOnly = false, recentDays = 30 },
+  onEvent
+) {
+  const res = await fetch(`${BASE}/sync`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ masteryCourseIds, skipSchoology, includeHidden, recentOnly, recentDays }),
+  });
+```
+
+- [ ] **Step 9: Run the full client suite + build**
+
+Run: `cd client && npx vitest run && npx vite build`
+Expected: PASS — all client tests green and the production build succeeds.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add client/src/components/SyncConfig.jsx client/src/components/SyncConfig.test.jsx client/src/components/SyncDialog.jsx client/src/services/api.js
+git commit -m "feat(sync): recent-only submission control in the Sync dialog (#55)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run every gate green**
+
+```bash
+npx vitest run server/
+cd client && npx vitest run && npx vite build
+```
+Expected: all server + client suites pass; production build succeeds.
+
+---
+
+## Notes for the implementer
+
+- **Rubric colours / inline-style convention:** N/A here — this feature touches the Sync dialog, not the rubric grid. Follow the standard `app.css` CSS-var + button-class convention; the `.number-stepper`, `.sync-help`, and `.sync-recent-days` class hooks above can be styled with existing variables (no new hard-coded hex).
+- **The "?" affordance** uses a native `title` tooltip — deliberately simple, no new visual component or design decision.
+- **Why `windowSkipped` is surfaced:** the spec requires no silent truncation. It already flows out of `syncSectionData`; wiring it into the progress/metrics display is a small follow-up and is *not* required for the green gate (the count is returned and available). If trivial, fold it into `fullSync`'s metrics aggregation alongside `submissions_skipped`.
+- **localStorage keys** use the repo's colon convention (`prism:sync:recent-only`, `prism:sync:recent-days`), consistent with `assessmentDraft.js`'s `prism:assessment-draft`.

--- a/docs/superpowers/specs/2026-06-06-recent-only-submission-sync-design.md
+++ b/docs/superpowers/specs/2026-06-06-recent-only-submission-sync-design.md
@@ -1,0 +1,146 @@
+# Recent-only submission-status sync — Design
+
+**Issue:** #55 (Perf: sync wall time dominated by per-(assignment, student) submission-status calls)
+**Date:** 2026-06-06
+**Status:** Design — pending user review
+
+## Goal
+
+Let the teacher restrict the expensive per-`(assignment × student)` submission-status check to assignments that are **due within a recent window or due in the future**, skipping clearly-old and undated assignments. This is the documented wall-time bottleneck in #55 (the submission-status pass calls `GET /sections/{id}/submissions/{aid}/{uid}` once per cell and scales O(N×M) per section).
+
+The feature is **opt-in and user-controlled**: a remembered default (per-browser) plus a per-sync override. When off, sync behaves exactly as today.
+
+This spec deliberately implements only **direction 1** from #55 ("scope-reduce the loop"). The heavier directions (lazy/background per-assignment sync; the rolled-back concurrency/429 work) are out of scope.
+
+## Scope
+
+**Windowed:** *only* the submission-status step in `server/services/sync.js` (the dropbox-filtered per-cell loop, ~`sync.js:214` onward).
+
+**Not windowed (always full):** courses, students, enrollments, assignments, grades, and mastery (SBG) sync. There is no correctness change anywhere outside the submission-status step.
+
+## User-facing behavior
+
+A new control appears in **Step 1 ("Schoology data — Always runs")** of the Sync dialog (`client/src/components/SyncConfig.jsx`), beside the existing *Include hidden courses* toggle:
+
+- **Checkbox** — *"Only check recent submissions"* (off by default).
+- **Day-window stepper** — a `[−] [N] [+]` control (visible/enabled only when the checkbox is on):
+  - The `N` field is directly editable (type a value).
+  - `[−]` / `[+]` decrement/increment by 1.
+  - Validated as a **positive integer, clamped 1–365**. Invalid/empty input falls back to the default (**30**).
+- **"?" info affordance** — a small info icon with hover text:
+  > "Skips submission checks for assignments with no due date and those due more than N days ago. Courses, students, assignments, grades and mastery still sync fully."
+
+**Remembered default + override:** the checkbox and day-window seed from `localStorage` on dialog open. Whatever the teacher runs with is written back to `localStorage` on Start, so the last-used setting becomes the remembered default. The teacher can override either value for any single sync.
+
+**Rationale for skipping undated assignments (decided with the user):** many formatives are created without a due date; the submission data teachers actually rely on (final-grade deliberation, reassessment eligibility) is for dated work. Undated work is treated as optional and skipped, with the "?" affordance making the omission visible rather than silent.
+
+## Filter semantics
+
+When `recentOnly` is **on** with window `N` days, a submission-bearing assignment is included in the submission-status pass iff:
+
+1. it is submission-bearing (the existing `allow_dropbox` gate at `sync.js:214`), **and**
+2. its due date is set (`a.due` is truthy), **and**
+3. `dueDate >= now − N days`, where `now` is the sync's reference timestamp already threaded into `syncSectionData`.
+
+Excluded when `recentOnly` is on: assignments with **no due date**, and assignments **due more than N days ago**. Future-due dated assignments are **included** (they may already have early submissions).
+
+When `recentOnly` is **off**: today's behavior — all `allow_dropbox` assignments — unchanged.
+
+**Date handling:** `a.due` is the raw Schoology due string. Parse with `new Date(a.due)`; an unparseable/`NaN` date is treated as undated (skipped). Comparison uses the server clock via the existing `now` parameter, so all sections in one sync share one cutoff.
+
+## Architecture & data flow
+
+The existing trigger chain is reused; the two new params (`recentOnly`, `recentDays`) ride alongside `includeHidden`:
+
+1. **`SyncConfig.jsx`** — owns the checkbox + stepper state (seeded from `localStorage`). On Start, calls `onStart(masteryCourseIds, { skipSchoology, includeHidden, recentOnly, recentDays })`.
+2. **`SyncDialog.jsx`** — `startSync(ids, { skipSchoology, includeHidden, recentOnly, recentDays })` forwards the opts to `runSync`.
+3. **`client/src/services/api.js` → `runSync(body, onEvent)`** — POSTs the body (now including `recentOnly`, `recentDays`) to `/sync`.
+4. **`server/routes/schoology.js` → `POST /sync`** — destructures `recentOnly`/`recentDays` from `req.body`, validates/clamps them (see Guardrails), and passes them into `runUnifiedSync({ ..., recentOnly, recentDays }, write)`.
+5. **Opts threading is via explicit destructures at each layer, not a generic spread** — each signature must be extended deliberately:
+   - `runUnifiedSync({ masteryCourseIds, skipSchoology, includeHidden, recentOnly = false, recentDays = 30 }, onEvent)` → forwards to `fullSync(onProgress, { includeHidden, recentOnly, recentDays })` (`syncOrchestrator.js:22` / call at `:34`).
+   - `fullSync(onProgress, { includeHidden = false, recentOnly = false, recentDays = 30 } = {})` (`sync.js:605`) → includes them in the explicit opts object passed to `syncSectionData` at `sync.js:723`: `{ ...syncConfig, recentOnly, recentDays, fetchSubmissionLookup }`.
+   - `syncSectionData(db, sectionId, courseId, now, opts)` destructures `recentOnly = false`, `recentDays = 30` from `opts` (next to the existing `submission*` options at `sync.js:58`).
+6. **`syncSectionData` window filter** — at the dropbox filter (`sync.js:214`), apply the window when `recentOnly`. Note `now` is an **ISO string** (`new Date().toISOString()`, `sync.js:608`), so the cutoff must parse it:
+   ```js
+   const dropboxAssignments = assignments.filter(a => a.allow_dropbox === '1' || a.allow_dropbox === 1);
+   const cutoff = Date.parse(now) - recentDays * 86400000; // now is an ISO string
+   const targetAssignments = recentOnly
+     ? dropboxAssignments.filter(a => {
+         const t = a.due ? Date.parse(a.due) : NaN;
+         return !Number.isNaN(t) && t >= cutoff;
+       })
+     : dropboxAssignments;
+   const windowSkipped = dropboxAssignments.length - targetAssignments.length;
+   ```
+   The per-cell loop then runs over `targetAssignments` instead of all dropbox assignments.
+
+## Persistence (client-only)
+
+New module `client/src/lib/syncPrefs.js`, mirroring `client/src/lib/assessmentDraft.js`:
+
+- Keys: `prism.sync.recentOnly` (`"true"`/`"false"`), `prism.sync.recentDays` (integer string).
+- `getSyncPrefs()` → `{ recentOnly: boolean, recentDays: number }`, applying defaults (off / 30) and the 1–365 clamp on read.
+- `setSyncPrefs({ recentOnly, recentDays })` → writes both keys (clamped). Storage failures are swallowed (private-mode safe), same as the draft module.
+
+The server stays stateless about the default; it only ever receives explicit per-request params.
+
+## Reporting (no silent truncation)
+
+`syncSectionData` adds the per-section `windowSkipped` count to its metrics/result so it surfaces in the sync progress/`sync_log`. The teacher can see how many assignments the window dropped — the speedup is visible and the omission is never silent.
+
+## Guardrails / validation
+
+`recentDays` is coerced and clamped in **two** places (client for UX, server because it must not trust the client):
+
+- coerce to integer; if `NaN`/missing → `30`.
+- clamp to `[1, 365]`.
+- `recentOnly` coerced to boolean; `recentOnly` true with a bad `recentDays` → default `30` (never silently disables the window).
+
+A shared clamp helper (e.g., `clampDays`) lives in `syncPrefs.js` (client) and is mirrored or re-implemented trivially server-side in the route.
+
+## Components & files
+
+**New**
+- `client/src/components/NumberStepper.jsx` — reusable `[−] [editable N] [+]` control (props: `value`, `onChange`, `min`, `max`, `aria-label`). Clamps to a positive-integer range. Mirrors the small-control convention of `TriCheckbox.jsx`.
+- `client/src/components/NumberStepper.test.jsx` — typing, step buttons, clamping at min/max, rejecting non-integers.
+- `client/src/lib/syncPrefs.js` + `client/src/lib/syncPrefs.test.js` — get/set/clamp/default.
+
+**Modified**
+- `client/src/components/SyncConfig.jsx` — add the checkbox, `NumberStepper`, "?" tooltip; seed from `getSyncPrefs()`; include `recentOnly`/`recentDays` in `onStart`; write `setSyncPrefs(...)` on Start.
+- `client/src/components/SyncDialog.jsx` — thread the two opts through `startSync` → `runSync`.
+- `client/src/services/api.js` — include `recentOnly`/`recentDays` in the `runSync` POST body.
+- `server/routes/schoology.js` — parse/validate the two params; pass into `runUnifiedSync`.
+- `server/services/sync.js` — extend `fullSync`'s opts destructure (`recentOnly`, `recentDays`); include them in the explicit `syncSectionData` opts object at `:723`; destructure them in `syncSectionData`; apply the window filter at the dropbox-filter site; track `windowSkipped`.
+- `server/services/syncOrchestrator.js` — extend `runUnifiedSync`'s destructure with `recentOnly`/`recentDays` and forward them in the explicit `fullSync(..., { includeHidden, recentOnly, recentDays })` call.
+
+## Testing
+
+**Server (`server/services/sync.test.js` + `server/routes/schoology.test.js`)**
+- window filter: a mix of assignments (due within N, due > N ago, future-due, undated) → with `recentOnly` true only recent+future *dated* survive; `recentOnly` false → all dropbox assignments survive.
+- `windowSkipped` equals the count dropped.
+- route passes `recentOnly`/`recentDays` through; clamps out-of-range and `NaN` to defaults.
+
+**Client**
+- `syncPrefs.test.js`: defaults, round-trip, clamp 1–365, bad input → 30.
+- `NumberStepper.test.jsx`: type a value, `[−]`/`[+]` step, clamp at bounds, reject non-integers.
+- `SyncConfig` behavior test: checking the box enables the stepper; Start calls `onStart` with the chosen `recentOnly`/`recentDays` and writes them to `localStorage`.
+
+**Green gate:** `npx vitest run server/`, `cd client && npx vitest run`, `cd client && npx vite build`.
+
+## Out of scope (YAGNI)
+
+- Lazy/background per-assignment submission sync (#55 direction 2).
+- The rolled-back concurrency/parallelization + 429/Retry-After work.
+- Server-side or cross-device remembered default (localStorage chosen).
+- Any change to mastery sync or the per-assignment on-demand sync (`POST /mastery/:courseId/assignment/:assignmentId/sync`).
+
+## Decisions locked
+
+| Decision | Choice |
+|---|---|
+| Control model | Remembered default (localStorage) + per-sync override |
+| Filter window | Due in last N days **or** future-due; **skip undated**; "?" affordance explains skipped |
+| Persistence | Browser `localStorage`; server stateless |
+| Day input | `[−] [N] [+]` stepper, editable, positive integer, clamped 1–365, default 30 |
+| Windowed scope | Submission-status step only; rest of sync unchanged |
+| Visibility | Report `windowSkipped` count (no silent truncation) |

--- a/server/routes/schoology.js
+++ b/server/routes/schoology.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { getDb } from '../db/index.js';
 import { runUnifiedSync } from '../services/syncOrchestrator.js';
+import { clampDays } from '../services/recentWindow.js';
 
 const router = Router();
 
@@ -24,12 +25,17 @@ router.post('/sync', async (req, res) => {
     masteryCourseIds = [],
     skipSchoology = false,
     includeHidden = false,
+    recentOnly = false,
+    recentDays = 30,
   } = req.body || {};
   res.set('Content-Type', 'application/x-ndjson');
   res.flushHeaders();
   const write = (evt) => res.write(JSON.stringify(evt) + '\n');
   try {
-    await runUnifiedSync({ masteryCourseIds, skipSchoology, includeHidden }, write);
+    await runUnifiedSync(
+      { masteryCourseIds, skipSchoology, includeHidden, recentOnly: !!recentOnly, recentDays: clampDays(recentDays) },
+      write,
+    );
   } catch (err) {
     console.error('[sync] Error:', err);
     write({ type: 'error', message: err.message });

--- a/server/routes/schoology.js
+++ b/server/routes/schoology.js
@@ -12,6 +12,8 @@ let syncInProgress = false;
 //   masteryCourseIds?: number[],
 //   skipSchoology?: boolean,
 //   includeHidden?: boolean,    // #56: opt in to syncing hidden courses
+//   recentOnly?: boolean,       // #55: skip submissions outside the day window
+//   recentDays?: number,        // #55: window size, clamped 1..365 (default 30)
 // }.
 // Note: if the client disconnects mid-stream the sync continues to completion
 // server-side; there is no cancellation on client disconnect.
@@ -33,7 +35,7 @@ router.post('/sync', async (req, res) => {
   const write = (evt) => res.write(JSON.stringify(evt) + '\n');
   try {
     await runUnifiedSync(
-      { masteryCourseIds, skipSchoology, includeHidden, recentOnly: !!recentOnly, recentDays: clampDays(recentDays) },
+      { masteryCourseIds, skipSchoology, includeHidden: !!includeHidden, recentOnly: !!recentOnly, recentDays: clampDays(recentDays) },
       write,
     );
   } catch (err) {

--- a/server/routes/schoology.test.js
+++ b/server/routes/schoology.test.js
@@ -108,3 +108,45 @@ describe('POST /api/sync', () => {
     }
   });
 });
+
+describe('POST /api/sync — recent-only params (#55)', () => {
+  let captured;
+  beforeEach(() => {
+    captured = null;
+    h.impl = async (opts, onEvent) => {
+      captured = opts;
+      onEvent({ type: 'summary', schoology: null, mastery: [], elapsedMs: 1 });
+    };
+  });
+
+  async function post(body) {
+    const { server, port } = startServer();
+    try {
+      const res = await fetch(`http://localhost:${port}/api/sync`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      await res.text(); // drain the ndjson stream
+    } finally {
+      server.close();
+    }
+  }
+
+  test('defaults to recentOnly false / 30 days when omitted', async () => {
+    await post({ masteryCourseIds: [] });
+    expect(captured.recentOnly).toBe(false);
+    expect(captured.recentDays).toBe(30);
+  });
+
+  test('passes through recentOnly and clamps recentDays into 1..365', async () => {
+    await post({ recentOnly: true, recentDays: 9999 });
+    expect(captured.recentOnly).toBe(true);
+    expect(captured.recentDays).toBe(365);
+  });
+
+  test('coerces a non-numeric recentDays to the default', async () => {
+    await post({ recentOnly: true, recentDays: 'abc' });
+    expect(captured.recentDays).toBe(30);
+  });
+});

--- a/server/routes/schoology.test.js
+++ b/server/routes/schoology.test.js
@@ -149,4 +149,9 @@ describe('POST /api/sync — recent-only params (#55)', () => {
     await post({ recentOnly: true, recentDays: 'abc' });
     expect(captured.recentDays).toBe(30);
   });
+
+  test('defaults an explicit null recentDays to 30', async () => {
+    await post({ recentOnly: true, recentDays: null });
+    expect(captured.recentDays).toBe(30);
+  });
 });

--- a/server/services/recentWindow.js
+++ b/server/services/recentWindow.js
@@ -1,0 +1,26 @@
+// #55: pure helpers for the recent-only submission-status window. No I/O.
+
+const DAY_MS = 86400000;
+
+// Restrict a list of assignments to those whose submission status is worth the
+// expensive per-cell check: due within the last `recentDays` days, or due in
+// the future. Undated and clearly-old assignments are dropped. When `recentOnly`
+// is false this is a pass-through. `now` is an ISO string (the sync's reference
+// timestamp), so it must be parsed before arithmetic.
+export function filterRecentAssignments(assignments, recentOnly, recentDays, now) {
+  if (!recentOnly) return { target: assignments, windowSkipped: 0 };
+  const cutoff = Date.parse(now) - recentDays * DAY_MS;
+  const target = assignments.filter((a) => {
+    const t = a.due ? Date.parse(a.due) : NaN;
+    return !Number.isNaN(t) && t >= cutoff;
+  });
+  return { target, windowSkipped: assignments.length - target.length };
+}
+
+// Coerce a day-window value to a positive integer in [1, 365]; non-numbers fall
+// back to `fallback`. Shared by the route (trust boundary) and syncSectionData.
+export function clampDays(value, fallback = 30) {
+  const n = Math.floor(Number(value));
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(365, Math.max(1, n));
+}

--- a/server/services/recentWindow.js
+++ b/server/services/recentWindow.js
@@ -26,6 +26,7 @@ export function filterRecentAssignments(assignments, recentOnly, recentDays, now
 // non-finite values (NaN, ±Infinity, non-numbers) fall back to `fallback`.
 // Shared by the route (trust boundary) and syncSectionData.
 export function clampDays(value, fallback = 30) {
+  if (value == null || value === '') return fallback;
   const n = Math.floor(Number(value));
   if (!Number.isFinite(n)) return fallback;
   return Math.min(365, Math.max(1, n));

--- a/server/services/recentWindow.js
+++ b/server/services/recentWindow.js
@@ -9,7 +9,11 @@ const DAY_MS = 86400000;
 // timestamp), so it must be parsed before arithmetic.
 export function filterRecentAssignments(assignments, recentOnly, recentDays, now) {
   if (!recentOnly) return { target: assignments, windowSkipped: 0 };
-  const cutoff = Date.parse(now) - recentDays * DAY_MS;
+  const nowMs = Date.parse(now);
+  // Invalid reference timestamp → pass-through rather than silently dropping
+  // every assignment (the safe failure mode is to check everything).
+  if (!Number.isFinite(nowMs)) return { target: assignments, windowSkipped: 0 };
+  const cutoff = nowMs - recentDays * DAY_MS;
   const target = assignments.filter((a) => {
     const t = a.due ? Date.parse(a.due) : NaN;
     return !Number.isNaN(t) && t >= cutoff;
@@ -17,8 +21,10 @@ export function filterRecentAssignments(assignments, recentOnly, recentDays, now
   return { target, windowSkipped: assignments.length - target.length };
 }
 
-// Coerce a day-window value to a positive integer in [1, 365]; non-numbers fall
-// back to `fallback`. Shared by the route (trust boundary) and syncSectionData.
+// Coerce a day-window value to a positive integer in [1, 365]: out-of-range
+// values (incl. negatives and values > 365) are clamped to the nearest bound;
+// non-finite values (NaN, ±Infinity, non-numbers) fall back to `fallback`.
+// Shared by the route (trust boundary) and syncSectionData.
 export function clampDays(value, fallback = 30) {
   const n = Math.floor(Number(value));
   if (!Number.isFinite(n)) return fallback;

--- a/server/services/recentWindow.test.js
+++ b/server/services/recentWindow.test.js
@@ -29,6 +29,19 @@ describe('filterRecentAssignments', () => {
     const { target } = filterRecentAssignments(all, true, 365, NOW);
     expect(target.map((a) => a.id)).toEqual(['r', 'o', 'f']); // old now inside 365d
   });
+
+  it('treats an invalid now timestamp as pass-through (no silent data loss)', () => {
+    const { target, windowSkipped } = filterRecentAssignments(all, true, 30, null);
+    expect(target).toBe(all);
+    expect(windowSkipped).toBe(0);
+  });
+
+  it('keeps an assignment due exactly at the cutoff and drops one just before', () => {
+    const atCutoff = { id: 'c', due: '2026-05-07T00:00:00.000Z' };
+    const justBefore = { id: 'b', due: '2026-05-06T23:59:59.999Z' };
+    const { target } = filterRecentAssignments([atCutoff, justBefore], true, 30, NOW);
+    expect(target.map((a) => a.id)).toEqual(['c']);
+  });
 });
 
 describe('clampDays', () => {

--- a/server/services/recentWindow.test.js
+++ b/server/services/recentWindow.test.js
@@ -52,6 +52,8 @@ describe('clampDays', () => {
     expect(clampDays(12.9)).toBe(12);
     expect(clampDays('abc')).toBe(30);
     expect(clampDays(undefined)).toBe(30);
+    expect(clampDays(null)).toBe(30);
+    expect(clampDays('')).toBe(30);
     expect(clampDays(50, 7)).toBe(50);
   });
 });

--- a/server/services/recentWindow.test.js
+++ b/server/services/recentWindow.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { filterRecentAssignments, clampDays } from './recentWindow.js';
+
+// Fixed reference instant → cutoff for 30 days is 2026-05-07.
+const NOW = '2026-06-06T00:00:00.000Z';
+const recent = { id: 'r', due: '2026-06-01' };  // within window
+const old = { id: 'o', due: '2026-01-01' };     // > 30 days ago
+const future = { id: 'f', due: '2026-12-01' };  // not yet due
+const undated = { id: 'u', due: null };         // no due date
+const all = [recent, old, future, undated];
+
+describe('filterRecentAssignments', () => {
+  it('passes everything through with no skips when recentOnly is off', () => {
+    expect(filterRecentAssignments(all, false, 30, NOW)).toEqual({ target: all, windowSkipped: 0 });
+  });
+
+  it('keeps recent + future dated, skips old + undated when recentOnly is on', () => {
+    const { target, windowSkipped } = filterRecentAssignments(all, true, 30, NOW);
+    expect(target.map((a) => a.id)).toEqual(['r', 'f']);
+    expect(windowSkipped).toBe(2);
+  });
+
+  it('treats an unparseable due date as undated (skipped)', () => {
+    const { target } = filterRecentAssignments([{ id: 'x', due: 'not-a-date' }], true, 30, NOW);
+    expect(target).toEqual([]);
+  });
+
+  it('widens the window with a larger recentDays', () => {
+    const { target } = filterRecentAssignments(all, true, 365, NOW);
+    expect(target.map((a) => a.id)).toEqual(['r', 'o', 'f']); // old now inside 365d
+  });
+});
+
+describe('clampDays', () => {
+  it('floors and clamps into 1..365, defaulting on non-numbers', () => {
+    expect(clampDays(30)).toBe(30);
+    expect(clampDays(0)).toBe(1);
+    expect(clampDays(500)).toBe(365);
+    expect(clampDays(12.9)).toBe(12);
+    expect(clampDays('abc')).toBe(30);
+    expect(clampDays(undefined)).toBe(30);
+    expect(clampDays(50, 7)).toBe(50);
+  });
+});

--- a/server/services/sync.js
+++ b/server/services/sync.js
@@ -633,6 +633,7 @@ export async function fullSync(onProgress, { includeHidden = false, recentOnly =
     const metrics = {
       submission_calls: 0,
       submissions_skipped: 0, // #55: public calls skipped via the GHD pre-filter
+      window_skipped: 0, // #55: assignments skipped by the recent-only due-date window
       rate_limit_hits: 0,
       transient_failures: 0,
       retries_attempted: 0,
@@ -736,6 +737,7 @@ export async function fullSync(onProgress, { includeHidden = false, recentOnly =
       });
       metrics.submission_calls += result.submissionAttempts || 0;
       metrics.submissions_skipped += result.submissionSkipped || 0;
+      metrics.window_skipped += result.windowSkipped || 0;
       metrics.rate_limit_hits += result.rateLimitHits || 0;
       metrics.transient_failures += result.transientFailures || 0;
       if (result.submissionAbandoned) metrics.abandoned = 1;
@@ -792,6 +794,9 @@ export async function fullSync(onProgress, { includeHidden = false, recentOnly =
     // uses the public API only). Close its browser now.
     if (submissionFetcher) { await submissionFetcher.close().catch(() => {}); submissionFetcher = null; }
     if (metrics.submissions_skipped > 0) log(`Skipped ${metrics.submissions_skipped} submission checks via gradebook pre-filter`);
+    if (metrics.window_skipped > 0) {
+      log(`Recent-only window skipped ${metrics.window_skipped} assignment${metrics.window_skipped === 1 ? '' : 's'} (undated or due > the chosen window).`);
+    }
 
     // Retry pass: one serial attempt for assignments that hit transient errors.
     // No rate limiter, no Retry-After honoring, no further retries on failure.

--- a/server/services/sync.js
+++ b/server/services/sync.js
@@ -14,6 +14,7 @@ import {
   getSection,
 } from './schoology.js';
 import { runWithLimits } from './rateLimitedRunner.js';
+import { filterRecentAssignments } from './recentWindow.js';
 import { createSubmissionFetcher } from './graderSubmissions.js';
 import { getSyncConfig } from '../middleware/featureGate.js';
 import { syncMasteryForCourse, hasMasterySession } from './masterySync.js';
@@ -59,6 +60,8 @@ export async function syncSectionData(db, sectionId, courseId, now, opts = {}) {
     submissionRatePerSec = 4,
     submissionAbandonAfter = 5,
     skipSubmissions = false,
+    recentOnly = false,
+    recentDays = 30,
   } = opts;
 
   const upsertStudent = db.prepare(`
@@ -209,9 +212,13 @@ export async function syncSectionData(db, sectionId, courseId, now, opts = {}) {
   // courses (GHD is blind for inactive sections). An empty list makes the
   // submission phase a clean no-op (lookup fetch is guarded by .length, the
   // loop doesn't iterate, writeSubmissions([]) is a no-op).
-  const dropboxAssignments = skipSubmissions
+  const dropboxAll = skipSubmissions
     ? []
     : assignments.filter(a => a.allow_dropbox === '1' || a.allow_dropbox === 1);
+  // #55: when recentOnly, restrict the per-cell submission check to assignments
+  // due within recentDays or in the future; skip undated + clearly-old work.
+  const { target: dropboxAssignments, windowSkipped } =
+    filterRecentAssignments(dropboxAll, recentOnly, recentDays, now);
 
   // Best-effort: null when no session / fetch fails — sync then behaves exactly
   // as before (public revisions API only).
@@ -361,6 +368,7 @@ export async function syncSectionData(db, sectionId, courseId, now, opts = {}) {
     submissionAbandoned,
     submissionAttempts,
     submissionSkipped,
+    windowSkipped,
     rateLimitHits,
     transientFailures,
   };
@@ -602,7 +610,7 @@ export async function backfillUnfinalizedArchived(db, now) {
   return courses.length;
 }
 
-export async function fullSync(onProgress, { includeHidden = false } = {}) {
+export async function fullSync(onProgress, { includeHidden = false, recentOnly = false, recentDays = 30 } = {}) {
   const db = getDb();
   const log = (msg) => onProgress?.({ message: msg });
   const now = new Date().toISOString();
@@ -722,6 +730,8 @@ export async function fullSync(onProgress, { includeHidden = false } = {}) {
       log(`Syncing "${sec.course_title}"...`);
       const result = await syncSectionData(db, sectionId, courseRow.id, now, {
         ...syncConfig,
+        recentOnly,
+        recentDays,
         fetchSubmissionLookup: submissionFetcher ? (sid) => submissionFetcher.fetch(sid) : undefined,
       });
       metrics.submission_calls += result.submissionAttempts || 0;

--- a/server/services/sync.test.js
+++ b/server/services/sync.test.js
@@ -731,6 +731,47 @@ describe('detectArchivedTransitions (#70)', () => {
   });
 });
 
+describe('syncSectionData — recent-only submission window (#55)', () => {
+  let db;
+  let courseId;
+  const NOW = '2026-06-06T00:00:00.000Z'; // 30-day cutoff = 2026-05-07
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    migrate(db);
+    courseId = db.prepare(
+      `INSERT INTO courses (schoology_section_id, course_name) VALUES ('sec-w', 'Window')`
+    ).run().lastInsertRowid;
+    getSectionEnrollments.mockReset();
+    getSectionAssignments.mockReset();
+    getSectionGrades.mockReset();
+    getSubmissionStatus.mockReset();
+    getSectionGrades.mockResolvedValue([]);
+    getSubmissionStatus.mockResolvedValue(null);
+    getSectionEnrollments.mockResolvedValue([
+      { id: '900001', uid: '700001', name_first: 'Ada', name_last: 'Lovelace', admin: '0' },
+      { id: '900002', uid: '700002', name_first: 'Alan', name_last: 'Turing', admin: '0' },
+    ]);
+    getSectionAssignments.mockResolvedValue([
+      { id: '5001', title: 'Recent',  published: 1, allow_dropbox: '1', due: '2026-06-01' },
+      { id: '5002', title: 'Old',     published: 1, allow_dropbox: '1', due: '2026-01-01' },
+      { id: '5003', title: 'Undated', published: 1, allow_dropbox: '1', due: null },
+    ]);
+  });
+
+  test('recentOnly skips old + undated dropbox assignments', async () => {
+    const result = await syncSectionData(db, 'sec-w', courseId, NOW, { recentOnly: true, recentDays: 30 });
+    expect(getSubmissionStatus).toHaveBeenCalledTimes(2); // 1 recent assignment × 2 students
+    expect(result.windowSkipped).toBe(2);
+  });
+
+  test('recentOnly off checks every dropbox assignment (unchanged)', async () => {
+    const result = await syncSectionData(db, 'sec-w', courseId, NOW, { recentOnly: false });
+    expect(getSubmissionStatus).toHaveBeenCalledTimes(6); // 3 assignments × 2 students
+    expect(result.windowSkipped).toBe(0);
+  });
+});
+
 describe('backfillUnfinalizedArchived (#70)', () => {
   let db;
   beforeEach(async () => {

--- a/server/services/syncOrchestrator.js
+++ b/server/services/syncOrchestrator.js
@@ -20,7 +20,7 @@ export function classifyMasteryError(err) {
 //   { type:'log', message }
 //   { type:'summary', schoology, mastery, elapsedMs, fatal? }
 export async function runUnifiedSync(
-  { masteryCourseIds = [], skipSchoology = false, includeHidden = false },
+  { masteryCourseIds = [], skipSchoology = false, includeHidden = false, recentOnly = false, recentDays = 30 },
   onEvent
 ) {
   const emit = (evt) => onEvent?.(evt);
@@ -33,7 +33,7 @@ export async function runUnifiedSync(
     try {
       const result = await fullSync(
         (progress) => emit({ type: 'log', message: progress.message }),
-        { includeHidden }
+        { includeHidden, recentOnly, recentDays }
       );
       summary.schoology = { records: result.records };
       emit({ phase: 'schoology', status: 'done', records: result.records });


### PR DESCRIPTION
## Summary
Adds an **opt-in, user-controlled** window that restricts the slow per-`(assignment × student)` submission-status sync to recently-due assignments — the documented wall-time bottleneck in #55 (direction 1).

- Teacher ticks **"Only check recent submissions"** in the Sync dialog and sets a day count via a `[−] N [+]` stepper. The choice is **remembered in `localStorage`** and **overridable per sync**.
- **Only the submission-status step is windowed** — courses, students, assignments, grades & mastery still sync fully.
- **Filter:** due within the last N days **or** future-due; **undated work is skipped** (with a "?" affordance explaining what's skipped, since dated work is what matters for final-grade deliberations / reassessment).
- Server **validates + clamps** (1–365, defaults 30) — it never trusts the client and stays stateless about the default. The skipped count is **logged in sync progress** so nothing is silently truncated.

## How it's built (TDD, backend-first)
- `server/services/recentWindow.js` — pure `filterRecentAssignments` + `clampDays` helpers
- `server/services/sync.js` / `syncOrchestrator.js` — window the dropbox loop, thread `recentOnly`/`recentDays`, aggregate + log `windowSkipped`
- `server/routes/schoology.js` — parse + clamp params on `POST /api/sync`
- client: `syncPrefs.js` (localStorage), `NumberStepper.jsx`, `SyncConfig` / `SyncDialog` / `api.js` wiring + minimal legibility CSS (existing vars only)

Each task was implemented test-first and passed a spec-compliance + code-quality review.

## Test plan
- [x] Server suite green — `npx vitest run server/` (171 passing)
- [x] Client suite green — `cd client && npx vitest run` (222 passing)
- [x] `cd client && npx vite build` succeeds
- [ ] Manual: Sync dialog → tick "Only check recent submissions", set days → run sync → confirm faster sync, the "Recent-only window skipped N assignments" progress line, and that the choice persists across dialog reopen
- [ ] Manual: leave unchecked → full sync behaves exactly as before

## References
- Spec: `docs/superpowers/specs/2026-06-06-recent-only-submission-sync-design.md`
- Plan: `docs/superpowers/plans/2026-06-06-recent-only-submission-sync.md`
- Addresses #55 (direction 1). Out of scope / deferred: direction 2 (lazy/background per-assignment sync) and the rolled-back concurrency/429 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)