### PR TITLE
feat(mcp): PrisMCP slice 5 — write_assessment_analysis

### DIFF
--- a/mcp/server.js
+++ b/mcp/server.js
@@ -4,7 +4,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { getDb } from '../server/db/index.js';
 import { getAssessmentContext } from '../server/services/assessmentContext.js';
-import { writeStudentSuggestions } from '../server/services/suggestions.js';
+import { writeStudentSuggestions, upsertAssessmentAnalysis } from '../server/services/suggestions.js';
 import { listCourses, listAssignments } from './handlers.js';
 
 // <2KB tool-search hint (spec §3.4) so a client knows when to surface PrisMCP.
@@ -92,6 +92,23 @@ export function createServer() {
     },
     async ({ assignment_id, students }) => ({
       content: [{ type: 'text', text: JSON.stringify(writeStudentSuggestions(getDb(), { assignmentId: assignment_id, students })) }],
+    })
+  );
+
+  server.registerTool(
+    'write_assessment_analysis',
+    {
+      description:
+        'Write the assessment-wide reviewer analysis (noticings + optional moderation note) for an assignment, shown in the Reviewer Analysis drawer in Prism.',
+      inputSchema: {
+        course_id: z.union([z.number(), z.string()]).describe('Local Prism course id'),
+        assignment_id: z.union([z.number(), z.string()]).describe('Schoology or local assignment id'),
+        noticings: z.array(z.object({ title: z.string(), body: z.string() })).describe('Class-level observations'),
+        moderation_note: z.string().optional(),
+      },
+    },
+    async ({ assignment_id, noticings, moderation_note }) => ({
+      content: [{ type: 'text', text: JSON.stringify(upsertAssessmentAnalysis(getDb(), { assignmentId: assignment_id, noticings, moderation_note })) }],
     })
   );
 

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -4,6 +4,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { getDb } from '../server/db/index.js';
 import { getAssessmentContext } from '../server/services/assessmentContext.js';
+import { writeStudentSuggestions } from '../server/services/suggestions.js';
 import { listCourses, listAssignments } from './handlers.js';
 
 // <2KB tool-search hint (spec §3.4) so a client knows when to surface PrisMCP.
@@ -63,6 +64,34 @@ export function createServer() {
       content: [
         { type: 'text', text: JSON.stringify(getAssessmentContext(getDb(), { courseId: course_id, assignmentId: assignment_id })) },
       ],
+    })
+  );
+
+  server.registerTool(
+    'write_student_suggestions',
+    {
+      description:
+        'Write AI grading suggestions (narrative + per-topic levels + reviewer flags) for a whole class in one batched call. Upserts one draft suggestion per student for teacher review in Prism; never writes to Schoology.',
+      inputSchema: {
+        course_id: z.union([z.number(), z.string()]).describe('Local Prism course id'),
+        assignment_id: z.union([z.number(), z.string()]).describe('Schoology or local assignment id'),
+        students: z
+          .array(
+            z.object({
+              student: z.union([z.number(), z.string()]).describe('schoology_uid or local student id'),
+              narrative_feedback: z.string().optional(),
+              rubric_scores: z.record(z.string(), z.string()).optional().describe('{ topic external_id|title: level code or full name }'),
+              reviewer_flags: z.string().nullable().optional(),
+              strengths: z.array(z.string()).optional(),
+              suggestions: z.array(z.string()).optional(),
+              score: z.number().optional(),
+            })
+          )
+          .describe('Whole-class batch, one entry per student'),
+      },
+    },
+    async ({ assignment_id, students }) => ({
+      content: [{ type: 'text', text: JSON.stringify(writeStudentSuggestions(getDb(), { assignmentId: assignment_id, students })) }],
     })
   );
 

--- a/mcp/server.test.js
+++ b/mcp/server.test.js
@@ -67,6 +67,31 @@ describe('PrisMCP server', () => {
     expect(ctx.students.map((s) => s.schoology_uid)).toEqual(['uid-1']);
   });
 
+  test('write_student_suggestions writes drafts and returns a per-student summary', async () => {
+    const db = getDb();
+    const courseId = db.prepare(`INSERT INTO courses (schoology_section_id, course_name) VALUES ('s1', 'AIML')`).run().lastInsertRowid;
+    db.prepare(`INSERT INTO reporting_categories (id, course_id, external_id, title) VALUES ('cat-1', ?, 'ART.5', 'Creating')`).run(courseId);
+    db.prepare(`INSERT INTO measurement_topics (id, category_id, course_id, external_id, title) VALUES ('topic-1', 'cat-1', ?, 'ART.5.1', 'Generates media')`).run(courseId);
+    const assignmentLocalId = db.prepare(`INSERT INTO assignments (course_id, schoology_assignment_id, title) VALUES (?, 'sa-1', 'Project')`).run(courseId).lastInsertRowid;
+    db.prepare(`INSERT INTO mastery_alignments (assignment_schoology_id, topic_id, course_id) VALUES ('sa-1', 'topic-1', ?)`).run(courseId);
+    db.prepare(`INSERT INTO students (schoology_uid, first_name, last_name) VALUES ('uid-1', 'Ada', 'Lovelace')`).run();
+
+    const client = await connect();
+    const res = await client.callTool({
+      name: 'write_student_suggestions',
+      arguments: {
+        course_id: courseId,
+        assignment_id: 'sa-1',
+        students: [{ student: 'uid-1', narrative_feedback: 'Strong work', rubric_scores: { 'ART.5.1': 'Exhibiting' } }],
+      },
+    });
+    const body = JSON.parse(res.content[0].text);
+    expect(body.results[0]).toMatchObject({ student: 'uid-1', status: 'written' });
+    const row = db.prepare('SELECT status, feedback_json FROM feedback WHERE assignment_id = ?').get(assignmentLocalId);
+    expect(row.status).toBe('draft');
+    expect(JSON.parse(row.feedback_json).rubric_scores).toEqual({ 'ART.5.1': 'EX' });
+  });
+
   test('advertises the tool-search instructions to the client', async () => {
     const client = await connect();
     expect(client.getInstructions()).toBe(INSTRUCTIONS);

--- a/mcp/server.test.js
+++ b/mcp/server.test.js
@@ -20,9 +20,9 @@ async function connect() {
 
 beforeEach(() => {
   getDb().exec(
-    'DELETE FROM feedback; DELETE FROM mastery_alignments; DELETE FROM mastery_scores; ' +
-    'DELETE FROM measurement_topics; DELETE FROM reporting_categories; DELETE FROM grades; ' +
-    'DELETE FROM enrolments; DELETE FROM assignments; DELETE FROM students; DELETE FROM courses;'
+    'DELETE FROM assessment_analysis; DELETE FROM feedback; DELETE FROM mastery_alignments; ' +
+    'DELETE FROM mastery_scores; DELETE FROM measurement_topics; DELETE FROM reporting_categories; ' +
+    'DELETE FROM grades; DELETE FROM enrolments; DELETE FROM assignments; DELETE FROM students; DELETE FROM courses;'
   );
 });
 
@@ -90,6 +90,30 @@ describe('PrisMCP server', () => {
     const row = db.prepare('SELECT status, feedback_json FROM feedback WHERE assignment_id = ?').get(assignmentLocalId);
     expect(row.status).toBe('draft');
     expect(JSON.parse(row.feedback_json).rubric_scores).toEqual({ 'ART.5.1': 'EX' });
+  });
+
+  test('write_assessment_analysis upserts the assessment-wide analysis row', async () => {
+    const db = getDb();
+    const courseId = db.prepare(`INSERT INTO courses (schoology_section_id, course_name) VALUES ('s1', 'AIML')`).run().lastInsertRowid;
+    const assignmentLocalId = db.prepare(`INSERT INTO assignments (course_id, schoology_assignment_id, title) VALUES (?, 'sa-1', 'Project')`).run(courseId).lastInsertRowid;
+
+    const client = await connect();
+    const res = await client.callTool({
+      name: 'write_assessment_analysis',
+      arguments: {
+        course_id: courseId,
+        assignment_id: 'sa-1',
+        noticings: [{ title: 'AI use', body: 'half the class leaned on it' }],
+        moderation_note: 'spot-check the borderline calls',
+      },
+    });
+    const body = JSON.parse(res.content[0].text);
+    expect(body).toMatchObject({ status: 'written', assignment_id: assignmentLocalId });
+    const row = db.prepare('SELECT analysis_json FROM assessment_analysis WHERE assignment_id = ?').get(assignmentLocalId);
+    expect(JSON.parse(row.analysis_json)).toEqual({
+      noticings: [{ title: 'AI use', body: 'half the class leaned on it' }],
+      moderation_note: 'spot-check the borderline calls',
+    });
   });
 
   test('advertises the tool-search instructions to the client', async () => {

--- a/server/services/suggestions.js
+++ b/server/services/suggestions.js
@@ -1,0 +1,106 @@
+// PrisMCP write path. Upserts AI grading suggestions into the existing feedback
+// table (and, for assessment-wide analysis, assessment_analysis) for teacher
+// review on /assessment/:id. Writes ONLY these two tables — never
+// mastery_scores, grades, or Schoology — so a re-grade can never clobber a
+// grade the teacher entered (spec §5).
+
+import { resolveStudentId, resolveAssignmentId } from './idResolvers.js';
+import { getAlignedTopics } from './assessmentContext.js';
+
+// Proficiency vocabulary (spec §4). Accept full names OR codes, case-insensitive;
+// normalize to the stored code. Anything else is reported, never written.
+const LEVEL_CODES = {
+  'exhibiting depth': 'ED', ed: 'ED',
+  exhibiting: 'EX', ex: 'EX',
+  developing: 'D', d: 'D',
+  emerging: 'EM', em: 'EM',
+  'insufficient evidence': 'IE', ie: 'IE',
+};
+
+export function normalizeLevel(raw) {
+  return LEVEL_CODES[String(raw).trim().toLowerCase()] ?? null;
+}
+
+// Upsert the single active suggestion for one (student, assignment). Normalizes
+// levels, resolves rubric keys against the assignment's aligned topics
+// (external_id then title, case-insensitive), and reports — never silently
+// drops — unresolved keys and out-of-vocabulary levels. Always writes a fresh
+// status='draft' row, pushing any prior feedback_json to revision_history.
+export function upsertStudentSuggestion(db, {
+  assignmentId, student, narrative_feedback, rubric_scores, reviewer_flags, strengths, suggestions, score,
+}) {
+  const studentLocalId = resolveStudentId(db, student);
+  if (!studentLocalId) return { student, status: 'error', message: `Student not found: ${student}` };
+  const assignmentLocalId = resolveAssignmentId(db, assignmentId);
+  if (!assignmentLocalId) return { student, status: 'error', message: `Assignment not found: ${assignmentId}` };
+
+  const assignmentRow = db.prepare('SELECT schoology_assignment_id, course_id FROM assignments WHERE id = ?').get(assignmentLocalId);
+  const topics = getAlignedTopics(db, assignmentRow.course_id, assignmentRow.schoology_assignment_id);
+  const byKey = new Map();
+  for (const t of topics) {
+    if (t.external_id) byKey.set(String(t.external_id).toLowerCase(), t);
+    if (t.title) byKey.set(String(t.title).toLowerCase(), t);
+  }
+
+  const storedScores = {};
+  const unresolvedTopics = [];
+  const invalidLevels = {};
+  for (const [key, rawLevel] of Object.entries(rubric_scores || {})) {
+    if (!byKey.has(String(key).toLowerCase())) { unresolvedTopics.push(key); continue; }
+    const code = normalizeLevel(rawLevel);
+    if (!code) { invalidLevels[key] = rawLevel; continue; }
+    storedScores[key] = code;
+  }
+
+  const feedbackJson = JSON.stringify({
+    narrative_feedback: narrative_feedback ?? '',
+    rubric_scores: storedScores,
+    reviewer_flags: reviewer_flags ?? null,
+    strengths: strengths ?? [],
+    suggestions: suggestions ?? [],
+  });
+
+  const write = db.transaction(() => {
+    // The single active suggestion = the most recent feedback row for this
+    // (student, assignment), regardless of status — a re-grade does not skip
+    // teacher_modified/approved rows (spec §5), it supersedes them as a fresh
+    // draft with the prior content preserved in revision_history.
+    const existing = db.prepare(
+      `SELECT * FROM feedback WHERE student_id = ? AND assignment_id = ?
+       ORDER BY updated_at DESC, id DESC LIMIT 1`
+    ).get(studentLocalId, assignmentLocalId);
+
+    if (existing) {
+      const history = JSON.parse(existing.revision_history || '[]');
+      history.push({
+        feedback_json: existing.feedback_json,
+        score: existing.score,
+        status: existing.status,
+        changed_at: new Date().toISOString(),
+      });
+      db.prepare(
+        `UPDATE feedback SET status = 'draft', score = ?, feedback_json = ?,
+           revision_history = ?, updated_at = datetime('now') WHERE id = ?`
+      ).run(score ?? null, feedbackJson, JSON.stringify(history), existing.id);
+      return existing.id;
+    }
+    return db.prepare(
+      `INSERT INTO feedback (student_id, assignment_id, status, score, feedback_json)
+       VALUES (?, ?, 'draft', ?, ?)`
+    ).run(studentLocalId, assignmentLocalId, score ?? null, feedbackJson).lastInsertRowid;
+  });
+
+  const feedbackId = write();
+  const result = { student, status: 'written', feedback_id: feedbackId };
+  if (unresolvedTopics.length) result.unresolved_topics = unresolvedTopics;
+  if (Object.keys(invalidLevels).length) {
+    result.message = `Ignored out-of-vocabulary levels: ${JSON.stringify(invalidLevels)}`;
+  }
+  return result;
+}
+
+// Batched whole-class write. Returns a per-student written/error summary.
+export function writeStudentSuggestions(db, { assignmentId, students }) {
+  const results = (students || []).map((s) => upsertStudentSuggestion(db, { assignmentId, ...s }));
+  return { results };
+}

--- a/server/services/suggestions.js
+++ b/server/services/suggestions.js
@@ -104,3 +104,24 @@ export function writeStudentSuggestions(db, { assignmentId, students }) {
   const results = (students || []).map((s) => upsertStudentSuggestion(db, { assignmentId, ...s }));
   return { results };
 }
+
+// Upsert the single assessment-wide analysis row (PK assignment_id) in the
+// shape the Reviewer Analysis drawer reads: { noticings: [{title, body}],
+// moderation_note? } (spec §4). assignmentId accepts a Schoology or local id.
+export function upsertAssessmentAnalysis(db, { assignmentId, noticings, moderation_note }) {
+  const assignmentLocalId = resolveAssignmentId(db, assignmentId);
+  if (!assignmentLocalId) return { status: 'error', message: `Assignment not found: ${assignmentId}` };
+
+  const analysisJson = JSON.stringify({
+    noticings: noticings ?? [],
+    ...(moderation_note != null ? { moderation_note } : {}),
+  });
+  db.prepare(`
+    INSERT INTO assessment_analysis (assignment_id, analysis_json, created_at, updated_at)
+    VALUES (?, ?, datetime('now'), datetime('now'))
+    ON CONFLICT(assignment_id) DO UPDATE SET
+      analysis_json = excluded.analysis_json,
+      updated_at = datetime('now')
+  `).run(assignmentLocalId, analysisJson);
+  return { status: 'written', assignment_id: assignmentLocalId };
+}

--- a/server/services/suggestions.test.js
+++ b/server/services/suggestions.test.js
@@ -3,7 +3,7 @@ import { describe, test, expect, beforeEach, vi } from 'vitest';
 vi.hoisted(() => { process.env.DB_PATH = ':memory:'; });
 
 import { getDb } from '../db/index.js';
-import { upsertStudentSuggestion, writeStudentSuggestions } from './suggestions.js';
+import { upsertStudentSuggestion, writeStudentSuggestions, upsertAssessmentAnalysis } from './suggestions.js';
 
 // A course with one aligned measurement topic (ART.5.1 / "Generates media"),
 // an assignment (Schoology id 'sa-1'), and one enrolled student (uid-1).
@@ -19,9 +19,9 @@ function seed(db) {
 
 beforeEach(() => {
   getDb().exec(
-    'DELETE FROM feedback; DELETE FROM mastery_alignments; DELETE FROM mastery_scores; ' +
-    'DELETE FROM measurement_topics; DELETE FROM reporting_categories; DELETE FROM grades; ' +
-    'DELETE FROM assignments; DELETE FROM students; DELETE FROM courses;'
+    'DELETE FROM assessment_analysis; DELETE FROM feedback; DELETE FROM mastery_alignments; ' +
+    'DELETE FROM mastery_scores; DELETE FROM measurement_topics; DELETE FROM reporting_categories; ' +
+    'DELETE FROM grades; DELETE FROM assignments; DELETE FROM students; DELETE FROM courses;'
   );
 });
 
@@ -122,5 +122,32 @@ describe('writeStudentSuggestions', () => {
     expect(results[0]).toMatchObject({ student: 'uid-1', status: 'written' });
     expect(results[1]).toMatchObject({ student: 'uid-missing', status: 'error' });
     expect(results[1].message).toMatch(/not found/i);
+  });
+});
+
+describe('upsertAssessmentAnalysis', () => {
+  test('upserts the single assessment_analysis row in the UI shape (one row, moderation optional)', () => {
+    const db = getDb();
+    const { assignmentLocalId } = seed(db);
+
+    const r1 = upsertAssessmentAnalysis(db, {
+      assignmentId: 'sa-1',
+      noticings: [{ title: 'AI use', body: 'half the class leaned on it' }],
+      moderation_note: 'spot-check the borderline EX/D calls',
+    });
+    expect(r1).toMatchObject({ status: 'written', assignment_id: assignmentLocalId });
+    expect(JSON.parse(db.prepare('SELECT analysis_json FROM assessment_analysis WHERE assignment_id = ?').get(assignmentLocalId).analysis_json))
+      .toEqual({ noticings: [{ title: 'AI use', body: 'half the class leaned on it' }], moderation_note: 'spot-check the borderline EX/D calls' });
+
+    // Re-run upserts (PK is assignment_id → one row); moderation omitted when absent.
+    upsertAssessmentAnalysis(db, { assignmentId: 'sa-1', noticings: [{ title: 'Integrity', body: 'all original' }] });
+    const all = db.prepare('SELECT analysis_json FROM assessment_analysis WHERE assignment_id = ?').all(assignmentLocalId);
+    expect(all).toHaveLength(1);
+    expect(JSON.parse(all[0].analysis_json)).toEqual({ noticings: [{ title: 'Integrity', body: 'all original' }] });
+  });
+
+  test('reports an error for an unknown assignment', () => {
+    expect(upsertAssessmentAnalysis(getDb(), { assignmentId: 'no-such', noticings: [] }))
+      .toMatchObject({ status: 'error' });
   });
 });

--- a/server/services/suggestions.test.js
+++ b/server/services/suggestions.test.js
@@ -1,0 +1,126 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+
+vi.hoisted(() => { process.env.DB_PATH = ':memory:'; });
+
+import { getDb } from '../db/index.js';
+import { upsertStudentSuggestion, writeStudentSuggestions } from './suggestions.js';
+
+// A course with one aligned measurement topic (ART.5.1 / "Generates media"),
+// an assignment (Schoology id 'sa-1'), and one enrolled student (uid-1).
+function seed(db) {
+  const courseId = db.prepare(`INSERT INTO courses (schoology_section_id, course_name) VALUES ('sec-1', 'AIML')`).run().lastInsertRowid;
+  db.prepare(`INSERT INTO reporting_categories (id, course_id, external_id, title) VALUES ('cat-1', ?, 'ART.5', 'Creating')`).run(courseId);
+  db.prepare(`INSERT INTO measurement_topics (id, category_id, course_id, external_id, title) VALUES ('topic-1', 'cat-1', ?, 'ART.5.1', 'Generates media')`).run(courseId);
+  const assignmentLocalId = db.prepare(`INSERT INTO assignments (course_id, schoology_assignment_id, title) VALUES (?, 'sa-1', 'Project')`).run(courseId).lastInsertRowid;
+  db.prepare(`INSERT INTO mastery_alignments (assignment_schoology_id, topic_id, course_id) VALUES ('sa-1', 'topic-1', ?)`).run(courseId);
+  const studentId = db.prepare(`INSERT INTO students (schoology_uid, first_name, last_name) VALUES ('uid-1', 'Ada', 'Lovelace')`).run().lastInsertRowid;
+  return { courseId, assignmentLocalId, studentId };
+}
+
+beforeEach(() => {
+  getDb().exec(
+    'DELETE FROM feedback; DELETE FROM mastery_alignments; DELETE FROM mastery_scores; ' +
+    'DELETE FROM measurement_topics; DELETE FROM reporting_categories; DELETE FROM grades; ' +
+    'DELETE FROM assignments; DELETE FROM students; DELETE FROM courses;'
+  );
+});
+
+describe('upsertStudentSuggestion', () => {
+  test('writes a draft feedback row with name→code normalized rubric scores', () => {
+    const db = getDb();
+    const { assignmentLocalId, studentId } = seed(db);
+
+    const result = upsertStudentSuggestion(db, {
+      assignmentId: 'sa-1',
+      student: 'uid-1',
+      narrative_feedback: 'Great depth of exploration.',
+      rubric_scores: { 'ART.5.1': 'Exhibiting Depth' },
+      reviewer_flags: 'check sources',
+    });
+
+    expect(result).toMatchObject({ student: 'uid-1', status: 'written' });
+    expect(typeof result.feedback_id).toBe('number');
+
+    const row = db.prepare('SELECT * FROM feedback WHERE id = ?').get(result.feedback_id);
+    expect(row.status).toBe('draft');
+    expect(row.student_id).toBe(studentId);
+    expect(row.assignment_id).toBe(assignmentLocalId);
+    const fj = JSON.parse(row.feedback_json);
+    expect(fj.narrative_feedback).toBe('Great depth of exploration.');
+    expect(fj.rubric_scores).toEqual({ 'ART.5.1': 'ED' });
+    expect(fj.reviewer_flags).toBe('check sources');
+  });
+
+  test('accepts level codes and reports out-of-vocabulary levels without storing them', () => {
+    const db = getDb();
+    seed(db);
+    const ok = upsertStudentSuggestion(db, { assignmentId: 'sa-1', student: 'uid-1', rubric_scores: { 'ART.5.1': 'ex' } });
+    expect(JSON.parse(db.prepare('SELECT feedback_json FROM feedback WHERE id = ?').get(ok.feedback_id).feedback_json).rubric_scores).toEqual({ 'ART.5.1': 'EX' });
+
+    const bad = upsertStudentSuggestion(db, { assignmentId: 'sa-1', student: 'uid-1', rubric_scores: { 'ART.5.1': 'Amazing' } });
+    expect(JSON.parse(db.prepare('SELECT feedback_json FROM feedback WHERE id = ?').get(bad.feedback_id).feedback_json).rubric_scores).toEqual({});
+    expect(bad.message).toMatch(/out-of-vocabulary/i);
+  });
+
+  test('resolves topic keys by external_id or title and reports unresolved keys', () => {
+    const db = getDb();
+    seed(db);
+    const r = upsertStudentSuggestion(db, {
+      assignmentId: 'sa-1', student: 'uid-1',
+      rubric_scores: { 'Generates media': 'Developing', 'ART.9.9': 'ED' },
+    });
+    expect(JSON.parse(db.prepare('SELECT feedback_json FROM feedback WHERE id = ?').get(r.feedback_id).feedback_json).rubric_scores)
+      .toEqual({ 'Generates media': 'D' });
+    expect(r.unresolved_topics).toEqual(['ART.9.9']);
+  });
+
+  test('re-grade upserts one row, re-activates as draft, and pushes prior content to revision_history', () => {
+    const db = getDb();
+    const { studentId, assignmentLocalId } = seed(db);
+    const first = upsertStudentSuggestion(db, { assignmentId: 'sa-1', student: 'uid-1', narrative_feedback: 'v1', rubric_scores: { 'ART.5.1': 'EX' } });
+    db.prepare(`UPDATE feedback SET status = 'approved' WHERE id = ?`).run(first.feedback_id);
+
+    const second = upsertStudentSuggestion(db, { assignmentId: 'sa-1', student: 'uid-1', narrative_feedback: 'v2', rubric_scores: { 'ART.5.1': 'ED' } });
+    expect(second.feedback_id).toBe(first.feedback_id);
+    expect(db.prepare('SELECT COUNT(*) n FROM feedback WHERE student_id = ? AND assignment_id = ?').get(studentId, assignmentLocalId).n).toBe(1);
+
+    const row = db.prepare('SELECT * FROM feedback WHERE id = ?').get(first.feedback_id);
+    expect(row.status).toBe('draft');
+    expect(JSON.parse(row.feedback_json).narrative_feedback).toBe('v2');
+    const history = JSON.parse(row.revision_history);
+    expect(history).toHaveLength(1);
+    expect(history[0].status).toBe('approved');
+    expect(JSON.parse(history[0].feedback_json).narrative_feedback).toBe('v1');
+  });
+
+  test('never touches mastery_scores or grades', () => {
+    const db = getDb();
+    const { studentId, assignmentLocalId } = seed(db);
+    db.prepare(`INSERT INTO mastery_scores (student_uid, assignment_schoology_id, topic_id, points, grade) VALUES ('uid-1', 'sa-1', 'topic-1', 75, 'EX')`).run();
+    db.prepare(`INSERT INTO grades (student_id, assignment_id, score, grade_comment) VALUES (?, ?, 88, 'teacher comment')`).run(studentId, assignmentLocalId);
+
+    upsertStudentSuggestion(db, { assignmentId: 'sa-1', student: 'uid-1', narrative_feedback: 'x', rubric_scores: { 'ART.5.1': 'ED' } });
+
+    expect(db.prepare(`SELECT points, grade FROM mastery_scores WHERE student_uid = 'uid-1' AND topic_id = 'topic-1'`).get()).toEqual({ points: 75, grade: 'EX' });
+    expect(db.prepare('SELECT score, grade_comment FROM grades WHERE student_id = ? AND assignment_id = ?').get(studentId, assignmentLocalId))
+      .toEqual({ score: 88, grade_comment: 'teacher comment' });
+  });
+});
+
+describe('writeStudentSuggestions', () => {
+  test('writes the batch and returns a per-student written/error summary', () => {
+    const db = getDb();
+    seed(db);
+    const { results } = writeStudentSuggestions(db, {
+      assignmentId: 'sa-1',
+      students: [
+        { student: 'uid-1', narrative_feedback: 'ok', rubric_scores: { 'ART.5.1': 'ED' } },
+        { student: 'uid-missing', narrative_feedback: 'nope' },
+      ],
+    });
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({ student: 'uid-1', status: 'written' });
+    expect(results[1]).toMatchObject({ student: 'uid-missing', status: 'error' });
+    expect(results[1].message).toMatch(/not found/i);
+  });
+});


### PR DESCRIPTION
## Slice 5 of #84 (PrisMCP server) — stacked on #97

`write_assessment_analysis(course_id, assignment_id, noticings, moderation_note?)` → upserts the single `assessment_analysis` row (PK `assignment_id`) in the exact shape the Reviewer Analysis drawer reads: `{ noticings: [{title, body}], moderation_note? }`. Accepts a Schoology or local assignment id; re-runs replace the row (no duplicates); `moderation_note` omitted when absent.

### Verification
- `npx vitest run` → **183 passed** (2 `upsertAssessmentAnalysis` unit tests + 1 MCP integration test).

> **Stacked PR:** base is `feat/prismcp-slice-4-write-suggestions` (#97).

Closes #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)