### PR TITLE
feat(mcp): PrisMCP slice 6 — @-mention resource mirror

### DIFF
--- a/mcp/server.js
+++ b/mcp/server.js
@@ -1,6 +1,6 @@
 import { pathToFileURL } from 'url';
 import { z } from 'zod';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { getDb } from '../server/db/index.js';
 import { getAssessmentContext } from '../server/services/assessmentContext.js';
@@ -110,6 +110,30 @@ export function createServer() {
     async ({ assignment_id, noticings, moderation_note }) => ({
       content: [{ type: 'text', text: JSON.stringify(upsertAssessmentAnalysis(getDb(), { assignmentId: assignment_id, noticings, moderation_note })) }],
     })
+  );
+
+  // Read-only @-mention mirror of the read tools (spec §3.2), so the teacher can
+  // inject Prism context into an ad-hoc chat without running the grade prompt.
+  const json = (uri, data) => ({ contents: [{ uri: uri.href, mimeType: 'application/json', text: JSON.stringify(data) }] });
+
+  server.registerResource(
+    'courses', 'prism://courses',
+    { title: 'Prism courses', description: 'Active Prism courses', mimeType: 'application/json' },
+    async (uri) => json(uri, listCourses(getDb()))
+  );
+
+  server.registerResource(
+    'assignments',
+    new ResourceTemplate('prism://course/{courseId}/assignments', { list: undefined }),
+    { title: 'Course assignments', description: "A course's assignments", mimeType: 'application/json' },
+    async (uri, { courseId }) => json(uri, listAssignments(getDb(), { course_id: courseId }))
+  );
+
+  server.registerResource(
+    'assignment-context',
+    new ResourceTemplate('prism://assignment/{courseId}/{assignmentId}/context', { list: undefined }),
+    { title: 'Assignment context', description: 'Roster, topics, grades + suggestions for an assignment', mimeType: 'application/json' },
+    async (uri, { courseId, assignmentId }) => json(uri, getAssessmentContext(getDb(), { courseId, assignmentId }))
   );
 
   return server;

--- a/mcp/server.test.js
+++ b/mcp/server.test.js
@@ -127,3 +127,30 @@ describe('PrisMCP server', () => {
     expect(db.pragma('busy_timeout', { simple: true })).toBe(5000);
   });
 });
+
+describe('PrisMCP resources (@-mention mirror)', () => {
+  test('prism://courses mirrors list_courses', async () => {
+    getDb().prepare(`INSERT INTO courses (schoology_section_id, course_name) VALUES ('s1', 'Robotics')`).run();
+    const client = await connect();
+    const res = await client.readResource({ uri: 'prism://courses' });
+    expect(JSON.parse(res.contents[0].text).map((c) => c.course_name)).toEqual(['Robotics']);
+  });
+
+  test('prism://course/{courseId}/assignments mirrors list_assignments', async () => {
+    const db = getDb();
+    const courseId = db.prepare(`INSERT INTO courses (schoology_section_id, course_name) VALUES ('s1', 'MAD')`).run().lastInsertRowid;
+    db.prepare(`INSERT INTO assignments (course_id, schoology_assignment_id, title) VALUES (?, 'a1', 'App Project')`).run(courseId);
+    const client = await connect();
+    const res = await client.readResource({ uri: `prism://course/${courseId}/assignments` });
+    expect(JSON.parse(res.contents[0].text).map((a) => a.title)).toEqual(['App Project']);
+  });
+
+  test('prism://assignment/{courseId}/{assignmentId}/context mirrors get_assignment_context', async () => {
+    const db = getDb();
+    const courseId = db.prepare(`INSERT INTO courses (schoology_section_id, course_name) VALUES ('s1', 'AIML')`).run().lastInsertRowid;
+    db.prepare(`INSERT INTO assignments (course_id, schoology_assignment_id, title) VALUES (?, 'sa-1', 'Project')`).run(courseId);
+    const client = await connect();
+    const res = await client.readResource({ uri: `prism://assignment/${courseId}/sa-1/context` });
+    expect(JSON.parse(res.contents[0].text).assignment.schoology_assignment_id).toBe('sa-1');
+  });
+});


### PR DESCRIPTION
## Slice 6 of #84 (PrisMCP server) — stacked on #98

Read-only `@`-mention mirror of the read tools (spec §3.2), reusing the existing handler fns (no duplicated query logic):
- `prism://courses` → `list_courses`
- `prism://course/{courseId}/assignments` → `list_assignments` (`ResourceTemplate`)
- `prism://assignment/{courseId}/{assignmentId}/context` → `get_assignment_context` (`ResourceTemplate`)

### Verification
- `npx vitest run` → **186 passed** (3 resource-read integration tests asserting each resource returns its tool's payload).

> **Stacked PR:** base is `feat/prismcp-slice-5-assessment-analysis` (#98).

Closes #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)