### PR TITLE
feat(mcp): PrisMCP slice 7 — grade-assignment prompt

### DIFF
--- a/mcp/server.js
+++ b/mcp/server.js
@@ -136,6 +136,39 @@ export function createServer() {
     async (uri, { courseId, assignmentId }) => json(uri, getAssessmentContext(getDb(), { courseId, assignmentId }))
   );
 
+  // Thin, path-free orchestration kickoff (spec §3.3). Carries NO grading
+  // content — it only wires get-context → follow the in-context {type}
+  // instructions → write back → stop for teacher review. References instructions
+  // and submissions by role/type, never by absolute path, so it ships in-repo.
+  server.registerPrompt(
+    'grade-assignment',
+    {
+      title: 'Grade an assignment (Prism)',
+      description: 'Wire a grading run: load Prism context, follow your in-context grading instructions, write suggestions back for review.',
+      argsSchema: {
+        assignment: z.string().describe('Which assignment to grade (free text; resolved via list_assignments)'),
+        assignment_type: z.string().optional().describe('Grading-skill hint, e.g. "portfolio" / "essay" (default "portfolio")'),
+      },
+    },
+    ({ assignment, assignment_type }) => ({
+      messages: [
+        {
+          role: 'user',
+          content: {
+            type: 'text',
+            text:
+              `You are grading **${assignment}**. If the assignment is ambiguous, call \`list_assignments\` to resolve ` +
+              `it. Call \`get_assignment_context\` to load the roster, aligned measurement topics, and current grading ` +
+              `state. Then follow your **${assignment_type || 'portfolio'}** grading instructions (already provided in ` +
+              `this chat's context) to grade the submissions provided in this chat. When done, call ` +
+              `\`write_student_suggestions\` (whole class, one call) and \`write_assessment_analysis\`, then **stop and ` +
+              `hand back to the teacher to review in Prism**.`,
+          },
+        },
+      ],
+    })
+  );
+
   return server;
 }
 

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -1,6 +1,6 @@
 import { pathToFileURL } from 'url';
 import { z } from 'zod';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { getDb } from '../server/db/index.js';
 import { getAssessmentContext } from '../server/services/assessmentContext.js';
@@ -110,6 +110,30 @@ export function createServer() {
     async ({ assignment_id, noticings, moderation_note }) => ({
       content: [{ type: 'text', text: JSON.stringify(upsertAssessmentAnalysis(getDb(), { assignmentId: assignment_id, noticings, moderation_note })) }],
     })
+  );
+
+  // Read-only @-mention mirror of the read tools (spec §3.2), so the teacher can
+  // inject Prism context into an ad-hoc chat without running the grade prompt.
+  const json = (uri, data) => ({ contents: [{ uri: uri.href, mimeType: 'application/json', text: JSON.stringify(data) }] });
+
+  server.registerResource(
+    'courses', 'prism://courses',
+    { title: 'Prism courses', description: 'Active Prism courses', mimeType: 'application/json' },
+    async (uri) => json(uri, listCourses(getDb()))
+  );
+
+  server.registerResource(
+    'assignments',
+    new ResourceTemplate('prism://course/{courseId}/assignments', { list: undefined }),
+    { title: 'Course assignments', description: "A course's assignments", mimeType: 'application/json' },
+    async (uri, { courseId }) => json(uri, listAssignments(getDb(), { course_id: courseId }))
+  );
+
+  server.registerResource(
+    'assignment-context',
+    new ResourceTemplate('prism://assignment/{courseId}/{assignmentId}/context', { list: undefined }),
+    { title: 'Assignment context', description: 'Roster, topics, grades + suggestions for an assignment', mimeType: 'application/json' },
+    async (uri, { courseId, assignmentId }) => json(uri, getAssessmentContext(getDb(), { courseId, assignmentId }))
   );
 
   return server;

--- a/mcp/server.test.js
+++ b/mcp/server.test.js
@@ -127,3 +127,30 @@ describe('PrisMCP server', () => {
     expect(db.pragma('busy_timeout', { simple: true })).toBe(5000);
   });
 });
+
+describe('PrisMCP resources (@-mention mirror)', () => {
+  test('prism://courses mirrors list_courses', async () => {
+    getDb().prepare(`INSERT INTO courses (schoology_section_id, course_name) VALUES ('s1', 'Robotics')`).run();
+    const client = await connect();
+    const res = await client.readResource({ uri: 'prism://courses' });
+    expect(JSON.parse(res.contents[0].text).map((c) => c.course_name)).toEqual(['Robotics']);
+  });
+
+  test('prism://course/{courseId}/assignments mirrors list_assignments', async () => {
+    const db = getDb();
+    const courseId = db.prepare(`INSERT INTO courses (schoology_section_id, course_name) VALUES ('s1', 'MAD')`).run().lastInsertRowid;
+    db.prepare(`INSERT INTO assignments (course_id, schoology_assignment_id, title) VALUES (?, 'a1', 'App Project')`).run(courseId);
+    const client = await connect();
+    const res = await client.readResource({ uri: `prism://course/${courseId}/assignments` });
+    expect(JSON.parse(res.contents[0].text).map((a) => a.title)).toEqual(['App Project']);
+  });
+
+  test('prism://assignment/{courseId}/{assignmentId}/context mirrors get_assignment_context', async () => {
+    const db = getDb();
+    const courseId = db.prepare(`INSERT INTO courses (schoology_section_id, course_name) VALUES ('s1', 'AIML')`).run().lastInsertRowid;
+    db.prepare(`INSERT INTO assignments (course_id, schoology_assignment_id, title) VALUES (?, 'sa-1', 'Project')`).run(courseId);
+    const client = await connect();
+    const res = await client.readResource({ uri: `prism://assignment/${courseId}/sa-1/context` });
+    expect(JSON.parse(res.contents[0].text).assignment.schoology_assignment_id).toBe('sa-1');
+  });
+});

--- a/mcp/server.test.js
+++ b/mcp/server.test.js
@@ -128,6 +128,31 @@ describe('PrisMCP server', () => {
   });
 });
 
+describe('grade-assignment prompt', () => {
+  test('expands to the path-free orchestration message that wires the loop', async () => {
+    const client = await connect();
+    const { messages } = await client.getPrompt({
+      name: 'grade-assignment',
+      arguments: { assignment: 'the MAD app project', assignment_type: 'essay' },
+    });
+    const text = messages[0].content.text;
+    expect(text).toContain('the MAD app project');
+    expect(text).toContain('essay');
+    for (const tool of ['list_assignments', 'get_assignment_context', 'write_student_suggestions', 'write_assessment_analysis']) {
+      expect(text).toContain(tool);
+    }
+    expect(text).toMatch(/review in Prism/i);
+    // Path-free: no absolute paths leak into the shipped prompt.
+    expect(text).not.toMatch(/\/Users\//);
+  });
+
+  test('defaults assignment_type to portfolio when omitted', async () => {
+    const client = await connect();
+    const { messages } = await client.getPrompt({ name: 'grade-assignment', arguments: { assignment: 'X' } });
+    expect(messages[0].content.text).toContain('portfolio');
+  });
+});
+
 describe('PrisMCP resources (@-mention mirror)', () => {
   test('prism://courses mirrors list_courses', async () => {
     getDb().prepare(`INSERT INTO courses (schoology_section_id, course_name) VALUES ('s1', 'Robotics')`).run();


### PR DESCRIPTION
## Slice 7 of #84 (PrisMCP server) — stacked on #99

The thin, **path-free** `grade-assignment` orchestration prompt (spec §3.3). Args: `assignment` (free text), `assignment_type` (free-form hint, default `"portfolio"`).

It carries **no grading content** — only wires the loop: resolve via `list_assignments` if ambiguous → `get_assignment_context` → follow the in-context `{assignment_type}` grading instructions → `write_student_suggestions` + `write_assessment_analysis` → **stop and hand back to the teacher to review in Prism**. References instructions/submissions by role/type, never by absolute path, so it ships in-repo.

This **completes the §3 surface**: 5 tools + 3 resources + 1 prompt.

### Verification
- `npx vitest run` → **188 passed** (2 prompt-expansion tests: wires the four tool calls + the stop instruction, defaults to portfolio, leaks no absolute paths).
- Real-stdio smoke confirms the full surface advertises over `npm run mcp`.

> **Stacked PR:** base is `feat/prismcp-slice-6-resource-mirror` (#99). After this merges down the stack, only #92 (HITL: Desktop/Cowork distribution + prompt-picker spike + e2e) remains.

Closes #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)