### PR TITLE
fix(sync): day-window stepper — select-on-focus + revert-on-empty

### DIFF
--- a/client/src/components/NumberStepper.jsx
+++ b/client/src/components/NumberStepper.jsx
@@ -1,22 +1,39 @@
-// A controlled [−] N [+] integer stepper. Emits clamped integer values via
-// onChange. Non-numeric typed input is ignored (the field stays controlled).
+import { useState } from 'react';
+
+// A [−] N [+] integer stepper. Valid keystrokes commit immediately (clamped) via
+// onChange. While focused the field holds raw text in `draft`, so it can be
+// cleared and retyped freely; focus selects the value for quick replacement, and
+// an empty/invalid field reverts to the committed value on blur.
 export default function NumberStepper({ value, onChange, min = 1, max = 365, ...rest }) {
   const clamp = (n) => Math.min(max, Math.max(min, Math.floor(n)));
   const emit = (n) => { if (Number.isFinite(n)) onChange(clamp(n)); };
+  // null = not editing (show the committed value); a string = the in-progress edit.
+  const [draft, setDraft] = useState(null);
   return (
     <span className="number-stepper">
       <button
         type="button" className="number-stepper__btn" aria-label="Decrease"
-        onClick={() => emit(value - 1)} disabled={value <= min}
+        onClick={() => { setDraft(null); emit(value - 1); }} disabled={value <= min}
       >−</button>
       <input
-        type="number" inputMode="numeric" min={min} max={max} value={value}
-        onChange={(e) => { const n = parseInt(e.target.value, 10); if (!Number.isNaN(n)) emit(n); }}
         {...rest}
+        type="number"
+        inputMode="numeric"
+        min={min}
+        max={max}
+        value={draft ?? String(value)}
+        onFocus={(e) => { setDraft(String(value)); e.target.select(); }}
+        onChange={(e) => {
+          setDraft(e.target.value);
+          const n = parseInt(e.target.value, 10);
+          if (!Number.isNaN(n)) emit(n);
+        }}
+        onBlur={() => setDraft(null)}
+        onKeyDown={(e) => { if (e.key === 'Enter') e.currentTarget.blur(); }}
       />
       <button
         type="button" className="number-stepper__btn" aria-label="Increase"
-        onClick={() => emit(value + 1)} disabled={value >= max}
+        onClick={() => { setDraft(null); emit(value + 1); }} disabled={value >= max}
       >+</button>
     </span>
   );

--- a/client/src/components/NumberStepper.test.jsx
+++ b/client/src/components/NumberStepper.test.jsx
@@ -36,4 +36,22 @@ describe('NumberStepper', () => {
     fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '12' } });
     expect(onChange).toHaveBeenLastCalledWith(12);
   });
+
+  it('selects the current value on focus for quick replacement', () => {
+    setup(30);
+    const input = screen.getByRole('spinbutton');
+    const selectSpy = vi.spyOn(input, 'select');
+    fireEvent.focus(input);
+    expect(selectSpy).toHaveBeenCalled();
+  });
+
+  it('reverts to the previous value when cleared and blurred', () => {
+    const { onChange } = setup(30);
+    const input = screen.getByRole('spinbutton');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+    expect(input).toHaveValue(30);            // reverted to the committed value
+    expect(onChange).not.toHaveBeenCalledWith(0); // clearing never commits a bad value
+  });
 });


### PR DESCRIPTION
## Summary
Follow-up UX fix for the recent-only day-window stepper (PR #96 / #55).

- **Click/focus selects the value**, so the user can type a replacement immediately.
- **Free editing:** while focused, the field holds raw text and can be cleared/retyped — it no longer snaps back mid-edit. Valid entries still commit immediately (clamped to 1–365).
- **Revert on empty:** clearing the field and blurring (deselecting with nothing typed) restores the previous value rather than committing a bad one.
- **Enter** commits and blurs.

Re. "what if 0?" — unchanged and safe: `0` clamps to `1` on both the stepper (`min=1`) and the server (`clampDays`), so the smallest window is 1 day; the sync never sees a 0-day window.

## Test plan
- [x] `cd client && npx vitest run` — 224 passing (2 new stepper tests: select-on-focus, revert-on-empty)
- [x] `cd client && npx vite build` succeeds
- [ ] Manual: open Sync dialog → tick the box → click the number (it selects) → type a new value; clear it and click away (reverts); try `0` (becomes 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)