### PR TITLE
feat(mcp): PrisMCP slice 8 — distribution + e2e (re-land of #102)

### DIFF
--- a/docs/prismcp-install-and-verify.md
+++ b/docs/prismcp-install-and-verify.md
@@ -1,0 +1,77 @@
+# PrisMCP — install & verify
+
+Operational guide for the PrisMCP server (spec: `docs/superpowers/specs/2026-06-06-prismcp-server.md`, tracking issue #84). PrisMCP is a local **stdio** MCP server that lets an interactive Claude grading session read a Prism course/assignment's roster, rubric measurement-topics, and current grades, and write AI grading **suggestions** back into Prism's local SQLite DB for teacher review on `/assessment/:id` (the violet ✦ layer). **It never writes to Schoology** and never reads submissions.
+
+Surface: tools `list_courses`, `list_assignments`, `get_assignment_context`, `write_student_suggestions`, `write_assessment_analysis`; `@`-mention resources `prism://courses`, `prism://course/{courseId}/assignments`, `prism://assignment/{courseId}/{assignmentId}/context`; and the `grade-assignment` prompt.
+
+## Install
+
+### Claude Code (committed, zero-config)
+
+The project-scoped `.mcp.json` at the repo root is committed, so on clone Claude Code offers to connect the `prism` server. Approve it once (the trust prompt, or `claude mcp`). It then surfaces:
+
+- prompt → `/mcp__prism__grade-assignment`
+- resources → `@prism:...`
+
+No paths to configure — the server resolves `students.db` relative to its own file (`mcp/server.js` → `../server/db/students.db`).
+
+### Claude Desktop / Cowork (absolute path)
+
+Desktop/Cowork spawn the server with an **absolute** command. Add to the Desktop MCP config (Settings → Developer → Edit Config, or the connector UI), then **restart Desktop**:
+
+```json
+{
+  "mcpServers": {
+    "prism": {
+      "command": "node",
+      "args": ["/Users/gnolan/Library/CloudStorage/OneDrive-HongKongInternationalSchool/_repos/prism/mcp/server.js"]
+    }
+  }
+}
+```
+
+- The DB resolves automatically (relative to the server file). Only add `"env": { "DB_PATH": "/abs/path/to/students.db" }` if your DB lives elsewhere.
+- The path contains spaces — keep it as a single array element (shown above); don't split it.
+
+## Verify
+
+### 1. Automated headless e2e — one command
+
+```bash
+npm run mcp:e2e
+```
+
+Seeds a **throwaway temp DB** (never `students.db`), spawns `mcp/server.js` over real stdio, runs the `grade-assignment` prompt + both write tools, then reads the result back from a separate ("Express-side") connection. Expect 5× `PASS`, proving the full loop and cross-process WAL coexistence (spec §7).
+
+Also useful: `npx vitest run` (the 188 unit/integration tests, incl. the MCP handlers, must stay green).
+
+### 2. Manual render check on `/assessment/:id`
+
+The headless e2e proves the data path; this confirms the pixels.
+
+1. `npm run dev` (Express :3001 + Vite :5173).
+2. Open a real assignment in the app and note its **course id** and **Schoology assignment id** (the assessment page URL / the mastery route uses the Schoology id).
+3. From **Claude Code** (where PrisMCP is connected via `.mcp.json`), run the real workflow against that assignment — `/mcp__prism__grade-assignment`, or call `write_student_suggestions` + `write_assessment_analysis` directly with one or two students.
+4. Reload `/assessment/:id` and confirm:
+   - [ ] violet ✦ dashed ring on the suggested rubric cell(s), **coexisting** with any teacher mark on the same row (agree-case = solid border + dashed ring + ✦);
+   - [ ] the `✦ Suggested feedback` box + `↑ Use suggestion`;
+   - [ ] the `⚑ Reviewer flags` strip (when `reviewer_flags` was written);
+   - [ ] the `✦ Reviewer Analysis` button → drawer with the proposed distribution + noticings (when `write_assessment_analysis` was called).
+5. **Concurrent check:** with the page open and the dev server running, run another `write_student_suggestions`; reload → the new ✦ appears (v1 has no live push, so a reload/refetch is expected).
+
+### 3. Cowork/Desktop prompt-picker spike — RESOLVED (2026-06-06, Claude Desktop)
+
+How PrisMCP surfaces in **Claude Desktop**: under the composer's **＋ → Connectors → Add from prism** submenu — **not** as `/` slash commands and **not** via `@`-mention (that's the Claude Code surface).
+
+- **`grade-assignment` prompt** → listed as **"Grade an assignment (Prism)"** (chat-bubble icon). Selecting it inserts the orchestration message; the `assignment` / `assignment_type` args are given inline in the chat.
+- **`prism://courses` resource** → listed as **"Prism courses"** (document icon). The *templated* resources (`.../assignments`, `.../context`) do **not** appear as menu items — they need parameters, so the agent reaches that data through the `list_assignments` / `get_assignment_context` **tools** instead.
+- **`@`-mention does nothing** for resources in Desktop — resource attachment lives in the "Add from prism" menu, not `@`.
+- In practice the picker is optional: a plain instruction at the end of a grading run — *"upload the student feedback to prism"* — makes the agent call the write tools directly. **Confirmed end-to-end on a real grading run.**
+
+Claude Code surfaces the same prompt as `/mcp__prism__grade-assignment` and resources as `@prism:...`.
+
+## Guardrails (confirmed 2026-06-06)
+
+- [x] The server contains **no** grading philosophy / rubric / extraction / output content, and **no** path outside the repo.
+- [x] It never writes to Schoology and never reads submissions.
+- [x] Writes target only the `feedback` and `assessment_analysis` tables — never `mastery_scores`, `grades`, or Schoology.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev:server": "node --watch server/index.js",
     "dev:client": "cd client && npx vite",
     "mcp": "node mcp/server.js",
+    "mcp:e2e": "node scripts/prismcp-e2e.mjs",
     "build": "cd client && npx vite build",
     "test:api": "node test-api.js",
     "test:server": "vitest run",

--- a/scripts/prismcp-e2e.mjs
+++ b/scripts/prismcp-e2e.mjs
@@ -1,0 +1,67 @@
+// PrisMCP end-to-end smoke (spec §12, headless portion). Run: `npm run mcp:e2e`.
+//
+// Seeds a THROWAWAY temp DB (never the real students.db), spawns mcp/server.js
+// as a real stdio subprocess, runs the grade-assignment prompt + both write
+// tools, then reads the result back from a SEPARATE ("Express-side")
+// connection to prove cross-process WAL coexistence (spec §7) and that the
+// written rows are in the shape /assessment/:id renders.
+import { rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, dirname } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const DB = join(tmpdir(), 'prismcp-e2e.db');
+for (const ext of ['', '-wal', '-shm']) { try { rmSync(DB + ext); } catch {} }
+process.env.DB_PATH = DB;
+
+const { getDb } = await import(pathToFileURL(join(ROOT, 'server/db/index.js')).href);
+const express = getDb(); // stands in for the running Express server's connection
+
+const courseId = express.prepare(`INSERT INTO courses (schoology_section_id, course_name, section_name) VALUES ('sec-e2e', 'AIML', 'Block A')`).run().lastInsertRowid;
+express.prepare(`INSERT INTO reporting_categories (id, course_id, external_id, title) VALUES ('cat-1', ?, 'ART.5', 'Creating')`).run(courseId);
+express.prepare(`INSERT INTO measurement_topics (id, category_id, course_id, external_id, title) VALUES ('topic-1', 'cat-1', ?, 'ART.5.1', 'Generates media')`).run(courseId);
+const aid = express.prepare(`INSERT INTO assignments (course_id, schoology_assignment_id, title, max_points) VALUES (?, 'sa-e2e', 'Generative Art Project', 100)`).run(courseId).lastInsertRowid;
+express.prepare(`INSERT INTO mastery_alignments (assignment_schoology_id, topic_id, course_id) VALUES ('sa-e2e', 'topic-1', ?)`).run(courseId);
+const sid = express.prepare(`INSERT INTO students (schoology_uid, first_name, last_name) VALUES ('uid-e2e', 'Ada', 'Lovelace')`).run().lastInsertRowid;
+express.prepare(`INSERT INTO enrolments (student_id, course_id, schoology_enrolment_id) VALUES (?, ?, 'enr-e2e')`).run(sid, courseId);
+express.prepare(`INSERT INTO grades (student_id, assignment_id, grade_comment, comment_status, exception) VALUES (?, ?, '', 1, 0)`).run(sid, aid);
+console.log(`seeded temp DB ${DB}: course ${courseId}, assignment sa-e2e (#${aid}), student uid-e2e`);
+
+const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
+const transport = new StdioClientTransport({ command: 'node', args: [join(ROOT, 'mcp/server.js')], env: { ...process.env, DB_PATH: DB }, cwd: ROOT });
+const client = new Client({ name: 'e2e', version: '1.0.0' });
+await client.connect(transport);
+console.log('MCP subprocess connected over stdio (Express connection already open → concurrent)');
+
+const checks = [];
+const prompt = await client.getPrompt({ name: 'grade-assignment', arguments: { assignment: 'Generative Art Project', assignment_type: 'portfolio' } });
+checks.push(['grade-assignment prompt wires the loop + stops for review', /review in Prism/i.test(prompt.messages[0].content.text)]);
+
+const w = JSON.parse((await client.callTool({ name: 'write_student_suggestions', arguments: {
+  course_id: courseId, assignment_id: 'sa-e2e',
+  students: [{ student: 'uid-e2e', narrative_feedback: 'Strong conceptual exploration; tighten the technical writeup.', rubric_scores: { 'ART.5.1': 'Exhibiting Depth' }, reviewer_flags: 'Confirm the dataset license.' }],
+} })).content[0].text);
+checks.push(['write_student_suggestions reports written', w.results?.[0]?.status === 'written']);
+
+const a = JSON.parse((await client.callTool({ name: 'write_assessment_analysis', arguments: {
+  course_id: courseId, assignment_id: 'sa-e2e',
+  noticings: [{ title: 'AI tool use', body: '~half the class used generative tools; all disclosed.' }],
+  moderation_note: 'Spot-check the EX/ED boundary.',
+} })).content[0].text);
+checks.push(['write_assessment_analysis reports written', a.status === 'written']);
+
+await client.close();
+
+// The Express-side connection (opened before the MCP subprocess existed) reads
+// the rows the MCP wrote — proving cross-process coexistence and the UI shape.
+const fb = express.prepare(`SELECT status, feedback_json FROM feedback WHERE assignment_id = ?`).get(aid);
+const an = express.prepare(`SELECT analysis_json FROM assessment_analysis WHERE assignment_id = ?`).get(aid);
+checks.push(['Express-side read sees a draft ✦ with normalized level (ED)', fb?.status === 'draft' && JSON.parse(fb.feedback_json).rubric_scores['ART.5.1'] === 'ED']);
+checks.push(['Express-side read sees the assessment analysis', JSON.parse(an?.analysis_json || '{}').noticings?.length === 1]);
+
+let ok = true;
+for (const [label, pass] of checks) { console.log(`${pass ? 'PASS' : 'FAIL'}  ${label}`); ok = ok && pass; }
+console.log(ok ? '\nPrisMCP e2e PASS' : '\nPrisMCP e2e FAIL');
+process.exit(ok ? 0 : 1);


### PR DESCRIPTION
Lands slice 8's net content on current main (the stacked #102 didn't merge — merge-commit artifact; its branch was based on pre-sync main). Adds `docs/prismcp-install-and-verify.md`, `scripts/prismcp-e2e.mjs`, and `npm run mcp:e2e`. No overlap with the sync work already on main.

Verified: `npx vitest run` → **201 passed**; `npm run mcp:e2e` → 5× PASS. Supersedes #102.

Closes #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)