### PR TITLE
Expose teacher-honored preferred name to grading agents + unify display logic

### DIFF
--- a/client/src/lib/studentNames.js
+++ b/client/src/lib/studentNames.js
@@ -1,0 +1,15 @@
+// Single source of truth for how a student is named for display, client-side.
+//
+// Precedence: a teacher-set override (`preferred_name_teacher`) beats
+// Schoology's synced preferred name (`preferred_name`), which beats the legal
+// `first_name`. This mirrors server/services/studentNames.js so the React pages
+// and the PrisMCP roster name a student identically. Empty strings count as
+// unset (`''` is falsy), so a blank override falls through to the next source.
+
+export function preferredFirstName(student) {
+  return student.preferred_name_teacher || student.preferred_name || student.first_name;
+}
+
+export function studentFullName(student) {
+  return [preferredFirstName(student), student.last_name].filter(Boolean).join(' ').trim();
+}

--- a/client/src/lib/studentNames.test.js
+++ b/client/src/lib/studentNames.test.js
@@ -1,0 +1,44 @@
+import { describe, test, expect } from 'vitest';
+import { preferredFirstName, studentFullName } from './studentNames.js';
+
+// Client mirror of server/services/studentNames.js — the single source of truth
+// for display-name precedence: teacher override > Schoology preferred > legal
+// first name. Keeping the client copy in lockstep means every page (and the
+// PrisMCP roster) names a student the same way.
+describe('preferredFirstName', () => {
+  test('prefers the teacher override above all else', () => {
+    expect(preferredFirstName({
+      preferred_name_teacher: 'Lexi', preferred_name: 'Ada', first_name: 'Adelaide',
+    })).toBe('Lexi');
+  });
+
+  test('falls back to the Schoology preferred name when no teacher override', () => {
+    expect(preferredFirstName({
+      preferred_name_teacher: null, preferred_name: 'Ada', first_name: 'Adelaide',
+    })).toBe('Ada');
+  });
+
+  test('falls back to the legal first name when neither preferred name is set', () => {
+    expect(preferredFirstName({
+      preferred_name_teacher: null, preferred_name: null, first_name: 'Adelaide',
+    })).toBe('Adelaide');
+  });
+
+  test('treats an empty-string preferred field as unset', () => {
+    expect(preferredFirstName({
+      preferred_name_teacher: '', preferred_name: '', first_name: 'Adelaide',
+    })).toBe('Adelaide');
+  });
+});
+
+describe('studentFullName', () => {
+  test('joins the resolved first name with the last name', () => {
+    expect(studentFullName({
+      preferred_name_teacher: 'Lexi', preferred_name: 'Ada', first_name: 'Adelaide', last_name: 'Lovelace',
+    })).toBe('Lexi Lovelace');
+  });
+
+  test('omits a missing last name without a trailing space', () => {
+    expect(studentFullName({ first_name: 'Ada', last_name: null })).toBe('Ada');
+  });
+});

--- a/client/src/pages/AssessmentSummaryPage.jsx
+++ b/client/src/pages/AssessmentSummaryPage.jsx
@@ -3,6 +3,7 @@ import { useParams, Link } from 'react-router-dom';
 import { getMasteryForAssignment, getFeedbackForAssignment, getAssessmentAnalysis, syncMasteryForAssignment, writeMasteryScores, writeMasteryComment, sendAllGrades, createFlag, deleteFlag, getRubricForAssignment, getRubricConfig } from '../services/api.js';
 import { draftKey, readDraft, writeDraft, clearDraft, draftBaseline } from '../lib/assessmentDraft.js';
 import { resolveRubricScores, distributionByTopic } from '../lib/rubricSuggestions.js';
+import { studentFullName } from '../lib/studentNames.js';
 import { useDataVersion } from '../hooks/useDataVersion.jsx';
 import { LEVELS, LEVEL_LABELS, LEVEL_COLORS, CELL_TEXT } from '../lib/masteryLevels.js';
 import { useProficiencyScale } from '../hooks/useProficiencyScale.js';
@@ -17,7 +18,7 @@ const SUGGEST = { fill: 'var(--ai-suggest-wash)', ring: 'var(--ai-suggest)', gly
 const REMOVE = '__remove__';
 
 function displayName(student) {
-  return `${student.preferred_name_teacher || student.preferred_name || student.first_name} ${student.last_name}`;
+  return studentFullName(student);
 }
 
 // Collapse soft line wraps from sources like PowerPoint text boxes into single

--- a/client/src/pages/CoursePage.jsx
+++ b/client/src/pages/CoursePage.jsx
@@ -10,6 +10,7 @@ import { masteryCodeForLevel, computeLetterGrade } from '../lib/masteryLevels.js
 import { useProficiencyScale } from '../hooks/useProficiencyScale.js';
 import { groupAssignmentsByFolder } from '../lib/assessmentGroups.js';
 import { gradYearToLevel } from '../lib/gradeLevel.js';
+import { preferredFirstName } from '../lib/studentNames.js';
 import { indexMastery, buildAssignmentRubric } from '../lib/gradebookMastery.js';
 import { useDataVersion } from '../hooks/useDataVersion.jsx';
 import CompactRubric from '../components/CompactRubric.jsx';
@@ -71,7 +72,7 @@ export default function CoursePage() {
   if (loading) return <div className="loading">Loading...</div>;
   if (!course) return <div className="error-msg">Course not found</div>;
 
-  const displayName = (s) => s.preferred_name_teacher || s.preferred_name || s.first_name;
+  const displayName = (s) => preferredFirstName(s);
 
   return (
     <div className="fade-in">
@@ -506,7 +507,7 @@ function MiniRubricStrip({ topics, onClick }) {
 // Modal opened from a MiniRubricStrip — the full rubric grid (shared
 // CompactRubric) plus the overall comment, matching the /student/ page.
 function RubricModal({ student, assignment, courseId, topics, comment, grade, onClose }) {
-  const name = student.preferred_name_teacher || student.preferred_name || student.first_name;
+  const name = preferredFirstName(student);
   // Submission state + flags, shown above the rubric — matching the /student/ page.
   const status = submissionStatus({
     score: grade.score, exception: grade.exception, late: grade.late,
@@ -703,7 +704,7 @@ function GradebookView({ data, courseId, mastery }) {
   }
 
   const { assignments, students, grades, grading_scales } = data;
-  const displayName = (s) => s.preferred_name_teacher || s.preferred_name || s.first_name;
+  const displayName = (s) => preferredFirstName(s);
 
   // Fixed table layout keeps every assessment column an identical width so the
   // diagonal headers stay uniform (#37); NAME_W must clear the longest name.

--- a/client/src/pages/FeedbackPage.jsx
+++ b/client/src/pages/FeedbackPage.jsx
@@ -7,6 +7,7 @@ import {
   getCourseAssignments, getGradingScales,
 } from '../services/api.js';
 import { gradeLabel } from '../lib/gradeLabel.js';
+import { studentFullName } from '../lib/studentNames.js';
 
 const STATUS_COLORS = {
   draft: 'badge-gray',
@@ -126,7 +127,7 @@ export default function FeedbackPage() {
                 }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                   <Link to={`/student/${item.student_id}`} className="link text-sm" onClick={e => e.stopPropagation()}>
-                    {item.preferred_name || item.first_name} {item.last_name}
+                    {studentFullName(item)}
                   </Link>
                   <span className={`badge ${STATUS_COLORS[item.status] || 'badge-gray'}`}>{item.status.replace('_', ' ')}</span>
                 </div>
@@ -211,7 +212,7 @@ function FeedbackDetail({ item, scales, onApprove, onDelete, onUpdate }) {
           <div>
             <h3>
               <Link to={`/student/${item.student_id}`} className="link">
-                {item.preferred_name || item.first_name} {item.last_name}
+                {studentFullName(item)}
               </Link>
             </h3>
             <p className="text-sm text-muted">{item.assignment_title} — {item.course_name}</p>
@@ -440,7 +441,7 @@ function ManualEntry({ courses, onDone }) {
           <label className="text-sm">Student</label>
           <select value={form.student_id} onChange={e => setForm(f => ({ ...f, student_id: e.target.value }))} required>
             <option value="">Select...</option>
-            {students.map(s => <option key={s.id} value={s.id}>{s.preferred_name || s.first_name} {s.last_name}</option>)}
+            {students.map(s => <option key={s.id} value={s.id}>{studentFullName(s)}</option>)}
           </select>
         </div>
         <div>

--- a/client/src/pages/SearchPage.jsx
+++ b/client/src/pages/SearchPage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { searchStudents } from '../services/api.js';
 import { gradYearToLevel } from '../lib/gradeLevel.js';
+import { preferredFirstName } from '../lib/studentNames.js';
 
 function matchesQuery(student, query) {
   if (!query.trim()) return true;
@@ -33,7 +34,7 @@ export default function SearchPage() {
 
   const results = allStudents.filter(s => matchesQuery(s, query));
 
-  const displayName = (s) => s.preferred_name_teacher || s.preferred_name || s.first_name;
+  const displayName = (s) => preferredFirstName(s);
 
   return (
     <div className="fade-in">

--- a/client/src/pages/StudentPage.jsx
+++ b/client/src/pages/StudentPage.jsx
@@ -12,6 +12,7 @@ import { gradeLabel, submissionStatus } from '../lib/gradeLabel.js';
 import { masteryCodeForLevel } from '../lib/masteryLevels.js';
 import { useDataVersion } from '../hooks/useDataVersion.jsx';
 import { formatGradeBadge } from '../lib/gradeLevel.js';
+import { preferredFirstName } from '../lib/studentNames.js';
 
 function CopyButton({ text, label }) {
   const [copied, setCopied] = useState(false);
@@ -321,8 +322,7 @@ export default function StudentPage() {
   if (loading) return <div className="loading">Loading...</div>;
   if (!student) return <div className="error-msg">Student not found</div>;
 
-  // Teacher-set preferred name wins, then Schoology preferred_name, then legal first_name
-  const displayName = student.preferred_name_teacher || student.preferred_name || student.first_name;
+  const displayName = preferredFirstName(student);
   const legalFullName = `${student.first_name} ${student.last_name}`;
   const displayedFullName = `${displayName} ${student.last_name}`;
   const showLegalName = legalFullName !== displayedFullName;

--- a/client/src/pages/ToolsPage.jsx
+++ b/client/src/pages/ToolsPage.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { getCourses, getEmails, getRandomStudents, getGroups } from '../services/api.js';
+import { studentFullName } from '../lib/studentNames.js';
 
 const GROUP_COLORS = [
   'var(--badge-blue-bg)', 'var(--badge-green-bg)', 'var(--warning-light)',
@@ -126,7 +127,7 @@ function RandomPicker({ courseIds }) {
   const [display, setDisplay] = useState(null);
   const intervalRef = useRef(null);
 
-  const displayName = (s) => `${s.preferred_name || s.first_name} ${s.last_name}`;
+  const displayName = (s) => studentFullName(s);
 
   async function handlePick() {
     setAnimating(true);
@@ -186,7 +187,7 @@ function GroupGenerator({ courseIds }) {
   const [balanced, setBalanced] = useState(false);
   const [groups, setGroups] = useState(null);
 
-  const displayName = (s) => `${s.preferred_name || s.first_name} ${s.last_name}`;
+  const displayName = (s) => studentFullName(s);
 
   async function handleGenerate() {
     const data = await getGroups(courseIds, groupCount, balanced);

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -54,7 +54,7 @@ export function createServer() {
     'get_assignment_context',
     {
       description:
-        'Load an assignment\'s roster, aligned measurement topics (rubric skeleton), current finals/comments/display-status, and any existing AI suggestions, to grade against.',
+        'Load an assignment\'s roster, aligned measurement topics (rubric skeleton), current finals/comments/display-status, and any existing AI suggestions, to grade against. Address each student in feedback by their roster `preferred_first_name` (the teacher-honored display name); `first_name`/`last_name` are the legal name, for matching submissions.',
       inputSchema: {
         course_id: z.union([z.number(), z.string()]).describe('Local Prism course id'),
         assignment_id: z.union([z.number(), z.string()]).describe('Schoology or local assignment id'),

--- a/server/routes/feedback.js
+++ b/server/routes/feedback.js
@@ -50,7 +50,7 @@ router.get('/', (req, res) => {
   const db = getDb();
   const { status, student_id, assignment_id, flagged, course_id } = req.query;
   let sql = `
-    SELECT f.*, s.first_name, s.last_name, s.preferred_name,
+    SELECT f.*, s.first_name, s.last_name, s.preferred_name, s.preferred_name_teacher,
            a.title as assignment_title, a.max_points, a.grading_scale_id,
            c.course_name, c.id as course_id
     FROM feedback f
@@ -73,7 +73,7 @@ router.get('/', (req, res) => {
 router.get('/:id', (req, res) => {
   const db = getDb();
   const row = db.prepare(`
-    SELECT f.*, s.first_name, s.last_name, s.preferred_name,
+    SELECT f.*, s.first_name, s.last_name, s.preferred_name, s.preferred_name_teacher,
            a.title as assignment_title, a.max_points, a.grading_scale_id,
            c.course_name, c.id as course_id
     FROM feedback f

--- a/server/routes/tools.js
+++ b/server/routes/tools.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { getDb } from '../db/index.js';
+import { preferredFirstName } from '../services/studentNames.js';
 
 const router = Router();
 
@@ -54,7 +55,7 @@ router.get('/emails/:courseId', (req, res) => {
 
   const fullName = (first, last) => [first, last].filter(Boolean).join(' ').trim();
   // Match the rest of the app: teacher override > Schoology preferred > first name
-  const studentName = (s) => fullName(s.preferred_name_teacher || s.preferred_name || s.first_name, s.last_name);
+  const studentName = (s) => fullName(preferredFirstName(s), s.last_name);
 
   const wantStudent = type === 'student' || type === 'both';
   const wantParent = type === 'parent' || type === 'both';
@@ -114,7 +115,7 @@ router.get('/random/:courseId', (req, res) => {
 
   // DISTINCT dedups students enrolled in more than one selected course
   const students = db.prepare(`
-    SELECT DISTINCT s.id, s.first_name, s.last_name, s.preferred_name
+    SELECT DISTINCT s.id, s.first_name, s.last_name, s.preferred_name, s.preferred_name_teacher
     FROM students s
     JOIN enrolments e ON e.student_id = s.id
     WHERE e.course_id IN (${placeholders})
@@ -148,7 +149,7 @@ router.get('/groups/:courseId', (req, res) => {
   // use the synced grade_percentage. avg_pct is NULL when a student has no
   // proficiency data yet, and those students are placed randomly below.
   let students = db.prepare(`
-    SELECT DISTINCT s.id, s.first_name, s.last_name, s.preferred_name,
+    SELECT DISTINCT s.id, s.first_name, s.last_name, s.preferred_name, s.preferred_name_teacher,
            (SELECT ROUND(AVG(mr.grade_percentage), 1)
             FROM mastery_rollups mr
             WHERE mr.student_uid = s.schoology_uid

--- a/server/services/assessmentContext.js
+++ b/server/services/assessmentContext.js
@@ -7,6 +7,7 @@
 // them into the PrisMCP get_assignment_context shape (spec §3.1).
 
 import { resolveAssignmentId } from './idResolvers.js';
+import { preferredFirstName } from './studentNames.js';
 
 // Aligned measurement topics for an assignment (the rubric skeleton), from the
 // authoritative mastery_alignments table; falls back to topics that have any
@@ -135,6 +136,9 @@ export function getAssessmentContext(db, { assignmentId }) {
       first_name: st.first_name,
       last_name: st.last_name,
       preferred_name: st.preferred_name,
+      // Resolved name to address the student by in suggested feedback — honors
+      // the teacher's override (preferred_name_teacher), matching the UI.
+      preferred_first_name: preferredFirstName(st),
       current_scores: Object.fromEntries(
         Object.entries(scoreMap[st.schoology_uid] || {}).map(([topicId, sc]) => [topicId, { level: sc.grade }])
       ),

--- a/server/services/assessmentContext.test.js
+++ b/server/services/assessmentContext.test.js
@@ -56,7 +56,11 @@ describe('getAssessmentContext', () => {
       schoology_uid: 'uid-1',
       enrollment_id: 'enr-1',
       first_name: 'Ada',
+      last_name: 'Lovelace',
       preferred_name: 'Ada',
+      // Resolved name the agent should address the student by (spec: name
+      // students correctly in suggested feedback).
+      preferred_first_name: 'Ada',
       grade_comment: 'Nice work',
       display_to_student: true,
       exception: 0,
@@ -68,6 +72,18 @@ describe('getAssessmentContext', () => {
       rubric_scores: { 'ART.5.1': 'ED' },
       reviewer_flags: 'check sources',
     });
+  });
+
+  test('resolves preferred_first_name from the teacher override, not the Schoology preferred name', () => {
+    const db = getDb();
+    seedContext(db);
+    // Teacher renamed Ada → "Lexi"; this override must win in the agent payload
+    // just as it does everywhere in the UI.
+    db.prepare(`UPDATE students SET preferred_name_teacher = 'Lexi' WHERE schoology_uid = 'uid-1'`).run();
+
+    const ctx = getAssessmentContext(db, { assignmentId: 'sa-1' });
+
+    expect(ctx.students[0].preferred_first_name).toBe('Lexi');
   });
 
   test('accepts a local assignment id as well as the Schoology id', () => {

--- a/server/services/studentNames.js
+++ b/server/services/studentNames.js
@@ -1,0 +1,19 @@
+// Single source of truth for how a student is named for display.
+//
+// App-wide precedence: a teacher-set override (`preferred_name_teacher`) beats
+// Schoology's synced preferred name (`preferred_name`), which beats the legal
+// `first_name`. The client pages (SearchPage, StudentPage, CoursePage, …) and
+// server/routes/tools.js all follow this order; centralising it here keeps the
+// PrisMCP roster naming students identically to the UI, so AI-suggested
+// feedback addresses each student by the name the teacher expects.
+//
+// Empty strings count as unset (`''` is falsy), so a blank override falls
+// through to the next source rather than blanking the name.
+
+export function preferredFirstName(student) {
+  return student.preferred_name_teacher || student.preferred_name || student.first_name;
+}
+
+export function studentFullName(student) {
+  return [preferredFirstName(student), student.last_name].filter(Boolean).join(' ').trim();
+}

--- a/server/services/studentNames.test.js
+++ b/server/services/studentNames.test.js
@@ -1,0 +1,55 @@
+import { describe, test, expect } from 'vitest';
+import { preferredFirstName, studentFullName } from './studentNames.js';
+
+// The app-wide display precedence: a teacher-set override beats Schoology's
+// synced preferred name, which beats the legal first name. These helpers are
+// the single source of truth so the MCP roster names students the same way the
+// UI does (server/routes/tools.js + the client pages all follow this order).
+describe('preferredFirstName', () => {
+  test('prefers the teacher override above all else', () => {
+    expect(preferredFirstName({
+      preferred_name_teacher: 'Lexi',
+      preferred_name: 'Ada',
+      first_name: 'Adelaide',
+    })).toBe('Lexi');
+  });
+
+  test('falls back to the Schoology preferred name when no teacher override', () => {
+    expect(preferredFirstName({
+      preferred_name_teacher: null,
+      preferred_name: 'Ada',
+      first_name: 'Adelaide',
+    })).toBe('Ada');
+  });
+
+  test('falls back to the legal first name when neither preferred name is set', () => {
+    expect(preferredFirstName({
+      preferred_name_teacher: null,
+      preferred_name: null,
+      first_name: 'Adelaide',
+    })).toBe('Adelaide');
+  });
+
+  test('treats an empty-string preferred field as unset', () => {
+    expect(preferredFirstName({
+      preferred_name_teacher: '',
+      preferred_name: '',
+      first_name: 'Adelaide',
+    })).toBe('Adelaide');
+  });
+});
+
+describe('studentFullName', () => {
+  test('joins the resolved first name with the last name', () => {
+    expect(studentFullName({
+      preferred_name_teacher: 'Lexi',
+      preferred_name: 'Ada',
+      first_name: 'Adelaide',
+      last_name: 'Lovelace',
+    })).toBe('Lexi Lovelace');
+  });
+
+  test('omits a missing last name without a trailing space', () => {
+    expect(studentFullName({ first_name: 'Ada', last_name: null })).toBe('Ada');
+  });
+});


### PR DESCRIPTION
## Why

The PrisMCP `get_assignment_context` roster — the only place an AI grading agent learns student names — surfaced **only** Schoology's `preferred_name` and the legal `first_name`. It silently dropped `preferred_name_teacher` (the teacher's explicit override) even though the roster query already fetched it. So suggested feedback couldn't reliably address students by the name the teacher expects.

The same precedence (`preferred_name_teacher || preferred_name || first_name`) was also re-inlined across six client pages, and two of them (**FeedbackPage**, **ToolsPage**) ignored the teacher override entirely — and their feeding routes didn't even `SELECT` the column.

## What

- **New single-source resolver** `server/services/studentNames.js` (+ a `client/src/lib/studentNames.js` mirror): `preferredFirstName()` / `studentFullName()`.
- **MCP payload** (`assessmentContext.js`): each student now includes a resolved `preferred_first_name` (honoring the override) + `last_name`. Existing fields untouched. The `get_assignment_context` tool description tells the agent to address students by it.
- **Data layer**: added `preferred_name_teacher` to the SELECTs feeding the two buggy pages (`feedback.js`, `tools.js` random/groups).
- **Client**: routed all six display sites (Feedback, Tools, Search, Student, Course, AssessmentSummary) through the shared helper.

## Testing (TDD)

- New `studentNames` unit tests (server + client): precedence + edge cases (empty-string override, missing last name).
- Extended `assessmentContext.test.js`: payload exposes `preferred_first_name`, and a teacher rename (`Ada` → `Lexi`) wins over the Schoology preferred name.
- Full suites green: **server 346, client 286**. Client production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)